### PR TITLE
Feature: 공통 입력 필드 컴포넌트

### DIFF
--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -8,7 +8,7 @@ const inputVariants = cva(
   {
     variants: {
       isError: {
-        true: 'ring-[#fca5a5]',
+        true: 'ring-danger-100',
         false:
           'ring-gray-300 focus:ring-primary-500 focus:border-none focus:ring-2',
       },

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -44,6 +44,7 @@ function Input({
   placeholder = '텍스트를 입력하세요',
   isRequired = false,
   isError = false,
+  errorMessage = '올바른 형식으로 입력해주세요',
   icon,
   className,
   ...props
@@ -73,7 +74,7 @@ function Input({
         />
       </div>
       <span className={cn(errorMessageVariants({ isError: isError }))}>
-        올바른 형식으로 입력해주세요
+        {errorMessage}
       </span>
     </label>
   )

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -66,8 +66,10 @@ function Input({
           type={type}
           placeholder={placeholder}
           className={cn(
-            inputVariants({ isError: isError, hasIcon: Boolean(icon) })
+            inputVariants({ isError: isError, hasIcon: Boolean(icon) }),
+            className
           )}
+          {...props}
         />
       </div>
       <span className={cn(errorMessageStyle({ isError: isError }))}>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -20,7 +20,7 @@ const inputVariants = cva(
   }
 )
 
-const errorMessageStyle = cva('text-sm', {
+const errorMessageVariants = cva('text-sm', {
   variants: {
     isError: {
       true: 'block text-danger-600',
@@ -72,7 +72,7 @@ function Input({
           {...props}
         />
       </div>
-      <span className={cn(errorMessageStyle({ isError: isError }))}>
+      <span className={cn(errorMessageVariants({ isError: isError }))}>
         올바른 형식으로 입력해주세요
       </span>
     </label>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,3 +1,5 @@
+import { Mail, Search } from 'lucide-react'
+
 function Input() {
   return (
     <label className="flex flex-col gap-2">
@@ -6,11 +8,15 @@ function Input() {
         <span className="text-danger-500">*</span>
       </div>
 
-      <input
-        type="text"
-        placeholder="이름을 입력하세요"
-        className="focus:ring-primary-500 rounded-lg p-1 px-[17px] py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2"
-      />
+      <div className="relative">
+        <Search className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
+        <Mail className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
+        <input
+          type="text"
+          placeholder="이름을 입력하세요"
+          className="focus:ring-primary-500 rounded-lg p-1 px-[17px] py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2"
+        />
+      </div>
     </label>
   )
 }

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -39,6 +39,7 @@ function Input({ icon, isRequired }) {
           className={inputStyle({ hasIcon: Boolean(icon) })}
         />
       </div>
+      <span>올바른 형식으로 입력해주세요</span>
     </label>
   )
 }

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -32,6 +32,7 @@ const errorMessageStyle = cva('text-sm', {
 interface InputProps
   extends ComponentProps<'input'>,
     VariantProps<typeof inputStyle> {
+  label: string
   isRequired?: boolean
   isError?: boolean
   icon?: string | null

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -13,7 +13,7 @@ const inputStyle = cva(
   }
 )
 
-function Input({ icon }) {
+function Input({ icon, isRequired }) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -63,7 +63,9 @@ function Input({
         <input
           type={type}
           placeholder={placeholder}
-          className={cn(inputVariants({ hasIcon: Boolean(icon) }))}
+          className={cn(
+            inputVariants({ isError: isError, hasIcon: Boolean(icon) })
+          )}
         />
       </div>
       <span className={cn(errorMessageStyle({ isError: isError }))}>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -18,6 +18,15 @@ const inputStyle = cva(
   }
 )
 
+const errorMessageStyle = cva('text-sm', {
+  variants: {
+    isError: {
+      true: 'block text-danger-600',
+      false: 'hidden',
+    },
+  },
+})
+
 function Input({ icon, isRequired }) {
   return (
     <label className="flex flex-col gap-2">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -46,7 +46,7 @@ function Input({ icon, isRequired }) {
         <input
           type="text"
           placeholder="이름을 입력하세요"
-          className={inputStyle({ hasIcon: Boolean(icon) })}
+          className={clsx(inputStyle({ hasIcon: Boolean(icon) }))}
         />
       </div>
       <span className={clsx(errorMessageStyle({ isError: isError }))}>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -28,7 +28,7 @@ const errorMessageStyle = cva('text-sm', {
   },
 })
 
-function Input({ icon, isRequired }) {
+function Input({ icon, isRequired, isError }) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,6 +1,7 @@
-import { cva } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority'
 import clsx from 'clsx'
 import { Mail, Search } from 'lucide-react'
+import type { ComponentProps } from 'react'
 
 const inputStyle = cva(
   'w-full focus:ring-primary-500 rounded-lg py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2',
@@ -27,6 +28,14 @@ const errorMessageStyle = cva('text-sm', {
     },
   },
 })
+
+interface InputProps
+  extends ComponentProps<'input'>,
+    VariantProps<typeof inputStyle> {
+  isRequired?: boolean
+  isError?: boolean
+  icon?: string | null
+}
 
 function Input({
   type = 'text',

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -35,6 +35,7 @@ interface InputProps
   label: string
   isRequired?: boolean
   isError?: boolean
+  errorMessage?: string
   icon?: 'search' | 'email'
 }
 

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -28,7 +28,14 @@ const errorMessageStyle = cva('text-sm', {
   },
 })
 
-function Input({ type, label, placeholder, icon, isRequired, isError }) {
+function Input({
+  type = 'text',
+  label = '라벨',
+  placeholder = '텍스트를 입력하세요',
+  isRequired = false,
+  isError = false,
+  icon,
+}) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,4 +1,17 @@
+import { cva } from 'class-variance-authority'
 import { Mail, Search } from 'lucide-react'
+
+const inputStyle = cva(
+  'w-full focus:ring-primary-500 rounded-lg py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2',
+  {
+    variants: {
+      hasIcon: {
+        true: 'pl-10 pr-[17px]',
+        false: 'px-[17px]',
+      },
+    },
+  }
+)
 
 function Input() {
   return (
@@ -14,7 +27,7 @@ function Input() {
         <input
           type="text"
           placeholder="이름을 입력하세요"
-          className="focus:ring-primary-500 rounded-lg p-1 px-[17px] py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2"
+          className={inputStyle({ hasIcon: Boolean(icon) })}
         />
       </div>
     </label>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -13,7 +13,7 @@ const inputStyle = cva(
   }
 )
 
-function Input() {
+function Input({ icon }) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -44,7 +44,7 @@ function Input({
   isRequired = false,
   isError = false,
   icon,
-}) {
+}: InputProps) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -18,7 +18,7 @@ function Input({ icon }) {
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">
         <span className="color-gray-700">이름</span>
-        <span className="text-danger-500">*</span>
+        {isRequired && <span className="text-danger-500">*</span>}
       </div>
 
       <div className="relative">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority'
+import clsx from 'clsx'
 import { Mail, Search } from 'lucide-react'
 
 const inputStyle = cva(
@@ -48,7 +49,9 @@ function Input({ icon, isRequired }) {
           className={inputStyle({ hasIcon: Boolean(icon) })}
         />
       </div>
-      <span>올바른 형식으로 입력해주세요</span>
+      <span className={clsx(errorMessageStyle({ isError: isError }))}>
+        올바른 형식으로 입력해주세요
+      </span>
     </label>
   )
 }

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,0 +1,18 @@
+function Input() {
+  return (
+    <label className="flex flex-col gap-2">
+      <div className="flex gap-1 text-sm font-medium">
+        <span className="color-gray-700">이름</span>
+        <span className="text-danger-500">*</span>
+      </div>
+
+      <input
+        type="text"
+        placeholder="이름을 입력하세요"
+        className="focus:ring-primary-500 rounded-lg p-1 px-[17px] py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2"
+      />
+    </label>
+  )
+}
+
+export default Input

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -45,6 +45,8 @@ function Input({
   isRequired = false,
   isError = false,
   icon,
+  className,
+  ...props
 }: InputProps) {
   return (
     <label className="flex flex-col gap-2">

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -35,7 +35,7 @@ interface InputProps
   label: string
   isRequired?: boolean
   isError?: boolean
-  icon?: string | null
+  icon?: 'search' | 'email'
 }
 
 function Input({

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -22,8 +22,12 @@ function Input() {
       </div>
 
       <div className="relative">
-        <Search className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
-        <Mail className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
+        {icon === 'search' && (
+          <Search className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
+        )}
+        {icon === 'email' && (
+          <Mail className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
+        )}
         <input
           type="text"
           placeholder="이름을 입력하세요"

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -5,6 +5,11 @@ const inputStyle = cva(
   'w-full focus:ring-primary-500 rounded-lg py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2',
   {
     variants: {
+      isError: {
+        true: 'ring-[#fca5a5]',
+        false:
+          'ring-gray-300 focus:ring-primary-500 focus:border-none focus:ring-2',
+      },
       hasIcon: {
         true: 'pl-10 pr-[17px]',
         false: 'px-[17px]',

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -28,11 +28,11 @@ const errorMessageStyle = cva('text-sm', {
   },
 })
 
-function Input({ icon, isRequired, isError }) {
+function Input({ type, label, placeholder, icon, isRequired, isError }) {
   return (
     <label className="flex flex-col gap-2">
       <div className="flex gap-1 text-sm font-medium">
-        <span className="color-gray-700">이름</span>
+        <span className="color-gray-700">{label}</span>
         {isRequired && <span className="text-danger-500">*</span>}
       </div>
 
@@ -44,8 +44,8 @@ function Input({ icon, isRequired, isError }) {
           <Mail className="absolute inset-y-0 left-2 my-auto h-4 text-gray-400" />
         )}
         <input
-          type="text"
-          placeholder="이름을 입력하세요"
+          type={type}
+          placeholder={placeholder}
           className={clsx(inputStyle({ hasIcon: Boolean(icon) }))}
         />
       </div>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority'
-import clsx from 'clsx'
+import { cn } from '@/utils'
 import { Mail, Search } from 'lucide-react'
 import type { ComponentProps } from 'react'
 
@@ -63,10 +63,10 @@ function Input({
         <input
           type={type}
           placeholder={placeholder}
-          className={clsx(inputStyle({ hasIcon: Boolean(icon) }))}
+          className={cn(inputStyle({ hasIcon: Boolean(icon) }))}
         />
       </div>
-      <span className={clsx(errorMessageStyle({ isError: isError }))}>
+      <span className={cn(errorMessageStyle({ isError: isError }))}>
         올바른 형식으로 입력해주세요
       </span>
     </label>

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/utils'
 import { Mail, Search } from 'lucide-react'
 import type { ComponentProps } from 'react'
 
-const inputStyle = cva(
+const inputVariants = cva(
   'w-full focus:ring-primary-500 rounded-lg py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2',
   {
     variants: {
@@ -31,7 +31,7 @@ const errorMessageStyle = cva('text-sm', {
 
 interface InputProps
   extends ComponentProps<'input'>,
-    VariantProps<typeof inputStyle> {
+    VariantProps<typeof inputVariants> {
   label: string
   isRequired?: boolean
   isError?: boolean
@@ -63,7 +63,7 @@ function Input({
         <input
           type={type}
           placeholder={placeholder}
-          className={cn(inputStyle({ hasIcon: Boolean(icon) }))}
+          className={cn(inputVariants({ hasIcon: Boolean(icon) }))}
         />
       </div>
       <span className={cn(errorMessageStyle({ isError: isError }))}>


### PR DESCRIPTION
## 🚀 PR 요약

공통 입력 필드 컴포넌트를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- Input 컴포넌트 UI 추가
- Input 컴포넌트 스타일 지정
- Input 컴포넌트 props 추가
- Input 컴포넌트 type 지정

### 참고 사항

**props는 모두 기본값이 적용되어 있으며, 아래와 같이 적용하시면 됩니다.**

- type - input 태그의 type 속성값 (ex:  text, email, password 등)
- label - 입력 필드의 라벨명 (ex: 이름, 비밀번호 확인 등)
- placeholder - input 태그의 placeholder 속성값 (ex:  이름을 입력하세요 등)
- icon - **search** 또는 **email** 입력 가능 (필요하지 않을 시 입력 X)
- isRequired - 필수 입력 항목일 때 추가
- isError - 입력 필드 유효성 확인이 필요할 때 추가 (유효성을 판단하는 함수를 적용하여 사용)

**예시**
```
<Input label="이름" placeholder="이름을 입력하세요" isRequired />

<Input label="검색" placeholder="검색어를 입력하세요" icon="search" />

<Input
  label="이메일"
  placeholder="이메일을 입력하세요"
  icon="email"
  isRequired
  isError={(입력 필드 유효성을 판단하는 함수)}
/>
```

### 스크린 샷

<div align='center'>
  <img src='https://github.com/user-attachments/assets/10e000fb-7758-4f15-9d24-6f540150b9ce' alt='input gif' width='500'/>
</div>

## 🔗 연관된 이슈

> closes #23
