### PR TITLE
Feature: 카드 컴포넌트

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps, ReactElement } from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/utils'
+
+function CardTitle() {
+  return <h1>Card Title</h1>
+}
+
+interface CardContentProps extends ComponentProps<'div'> {}
+
+function CardContent({ children }: CardContentProps) {
+  return <div>{children}</div>
+}
+
+const cardVariants = cva('rounded p-[25px] bg-white', {
+  variants: {
+    variant: {
+      default: 'border border-gray-200',
+      outline: 'border-2 border-gray-300',
+      elavate: 'shadow-lg border border-gray-100',
+      flat: 'border-0',
+    },
+  },
+
+  defaultVariants: {
+    variant: 'default',
+  },
+})
+
+interface CardProps
+  extends ComponentProps<'div'>,
+    VariantProps<typeof cardVariants> {
+  children:
+    | ReactElement<typeof CardContent> // 제목 없는 경우
+    | [ReactElement<typeof CardTitle>, ReactElement<typeof CardContent>] // 제목 있는 경우
+}
+
+function Card({ children, variant, className }: CardProps) {
+  return (
+    <div className={cn(cardVariants({ variant }), className)}>{children}</div>
+  )
+}
+
+export { Card, CardTitle, CardContent }

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -2,17 +2,23 @@ import type { ComponentProps, ReactElement } from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/utils'
 
-function CardTitle() {
-  return <h1>Card Title</h1>
+function CardTitle({ children, className, ...props }: ComponentProps<'h3'>) {
+  return (
+    <h3 className={cn('text-base font-semibold', className)} {...props}>
+      {children}
+    </h3>
+  )
 }
 
-interface CardContentProps extends ComponentProps<'div'> {}
-
-function CardContent({ children }: CardContentProps) {
-  return <div>{children}</div>
+function CardContent({ children, className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div className={cn('gray-600 text-sm', className)} {...props}>
+      {children}
+    </div>
+  )
 }
 
-const cardVariants = cva('rounded p-[25px] bg-white', {
+const cardVariants = cva('rounded-lg p-6 bg-white', {
   variants: {
     variant: {
       default: 'border border-gray-200',
@@ -35,9 +41,11 @@ interface CardProps
     | [ReactElement<typeof CardTitle>, ReactElement<typeof CardContent>] // 제목 있는 경우
 }
 
-function Card({ children, variant, className }: CardProps) {
+function Card({ children, variant, className, ...props }: CardProps) {
   return (
-    <div className={cn(cardVariants({ variant }), className)}>{children}</div>
+    <div className={cn(cardVariants({ variant }), className)} {...props}>
+      {children}
+    </div>
   )
 }
 

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -23,7 +23,7 @@ const cardVariants = cva('rounded-lg p-6 bg-white', {
     variant: {
       default: 'border border-gray-200',
       outline: 'border-2 border-gray-300',
-      elavate: 'shadow-lg border border-gray-100',
+      elevate: 'shadow-lg border border-gray-100',
       flat: 'border-0',
     },
   },

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactElement } from 'react'
+import type { ComponentProps, ReactElement, ReactNode } from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/utils'
 
@@ -33,12 +33,14 @@ const cardVariants = cva('rounded-lg p-6 bg-white', {
   },
 })
 
+type RecommendedChildren =
+  | ReactElement<typeof CardContent>
+  | [ReactElement<typeof CardTitle>, ReactElement<typeof CardContent>]
+
 interface CardProps
   extends ComponentProps<'div'>,
     VariantProps<typeof cardVariants> {
-  children:
-    | ReactElement<typeof CardContent> // 제목 없는 경우
-    | [ReactElement<typeof CardTitle>, ReactElement<typeof CardContent>] // 제목 있는 경우
+  children: RecommendedChildren | ReactNode
 }
 
 function Card({ children, variant, className, ...props }: CardProps) {
@@ -49,4 +51,4 @@ function Card({ children, variant, className, ...props }: CardProps) {
   )
 }
 
-export { Card, CardTitle, CardContent }
+export { Card, CardTitle, CardContent, type CardProps }

--- a/src/components/common/Card/ImageCard.tsx
+++ b/src/components/common/Card/ImageCard.tsx
@@ -1,0 +1,26 @@
+import { Card, type CardProps } from '@/components/common/Card/Card'
+import { cn } from '@/utils'
+
+interface ImageCardProps extends CardProps {
+  imageUrl: string
+}
+
+export default function ImageCard({
+  imageUrl,
+  children,
+  className = '',
+  ...props
+}: ImageCardProps) {
+  return (
+    <Card className={cn('p-0', className)} {...props}>
+      <div
+        className={cn(
+          'aspect-[16/9] overflow-hidden rounded-t-lg object-cover object-center'
+        )}
+      >
+        <img src={imageUrl} alt="" className="h-full w-full object-cover" />
+      </div>
+      <div className="p-6">{children}</div>
+    </Card>
+  )
+}

--- a/src/components/common/Card/ImageCard.tsx
+++ b/src/components/common/Card/ImageCard.tsx
@@ -12,12 +12,8 @@ export default function ImageCard({
   ...props
 }: ImageCardProps) {
   return (
-    <Card className={cn('p-0', className)} {...props}>
-      <div
-        className={cn(
-          'aspect-[16/9] overflow-hidden rounded-t-lg object-cover object-center'
-        )}
-      >
+    <Card className={cn('overflow-hidden p-0', className)} {...props}>
+      <div className={cn('aspect-[16/9] object-cover object-center')}>
         <img src={imageUrl} alt="" className="h-full w-full object-cover" />
       </div>
       <div className="p-6">{children}</div>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,5 +1,6 @@
 // components
 import Badge from '@/components/common/Badge'
 import Button from '@/components/common/Button'
+import ImageCard from '@/components/common/Card/ImageCard'
 
-export { Badge, Button }
+export { Badge, Button, ImageCard }


### PR DESCRIPTION
## 🚀 PR 요약

> 카드 컴포넌트와 이미지 카드 컴포넌트

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 카드 컴포넌트
  - Card: Wrapper component
    - variant: default, outline, elevate, flat 
  - CardTitle: 카드 타이틀
  - CardContent: 카드 내용
- 이미지 카드 컴포넌트
  - 위 카드 컴포넌트와 동일


### 참고 사항

- 예시 코드
```jsx
    <div className="flex flex-col items-center justify-center gap-10 p-10">
      <Card className="w-60">
        <CardTitle>기본 카드</CardTitle>
        <CardContent>기본 카드 입니다.</CardContent>
      </Card>

      <Card variant={'outline'} className="w-60">
        <CardTitle>테두리 카드</CardTitle>
        <CardContent>테두리 카드입니다.</CardContent>
      </Card>

      <Card variant={'elavate'} className="w-60">
        <CardTitle>그림자 카드</CardTitle>
        <CardContent>그림자 카드입니다.</CardContent>
      </Card>

      <Card variant={'flat'} className="w-60">
        <CardTitle>플랫 카드</CardTitle>
        <CardContent>플랫 카드입니다.</CardContent>
      </Card>

      <ImageCard
        imageUrl="https://dummyimage.com/600x400/000/fff"
        className="w-60"
        variant="default"
      >
        <CardTitle>이미지 카드</CardTitle>
        <CardContent>이미지 카드입니다.</CardContent>
      </ImageCard>
    </div>
```

### 스크린 샷

<img width="313" height="823" alt="Screenshot 2025-09-01 at 1 40 32 PM" src="https://github.com/user-attachments/assets/1dd2a850-d698-4863-ab44-92449a98c8f9" />


## 🔗 연관된 이슈

> closes #21
