### PR TITLE
Fix: 공용 입력 필드 컴포넌트 버그 수정

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -52,10 +52,12 @@ function Input({
 }: InputProps) {
   return (
     <label className="flex flex-col gap-2">
-      <div className="flex gap-1 text-sm font-medium">
-        {label && <span className="color-gray-700">{label}</span>}
-        {isRequired && <span className="text-danger-500">*</span>}
-      </div>
+      {label && (
+        <div className="flex gap-1 text-sm font-medium">
+          <span className="color-gray-700">{label}</span>
+          {isRequired && <span className="text-danger-500">*</span>}
+        </div>
+      )}
 
       <div className="relative">
         {icon === 'search' && (


### PR DESCRIPTION
## 🚀 PR 요약

입력 필드 컴포넌트의 props인 label의 값을 지정하지 않았는데도 공간을 갖는 버그가 발생하지 않도록 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 스크린 샷

입력 필드가 갖는 공간의 사이즈 확인을 위해 스크린 샷을 찍을 때 전체 요소를 감싸는 div 태그에 임시로 **bg-amber-100** 스타일 속성을 추가했습니다.

**수정 전**
<img width="908" height="115" alt="image" src="https://github.com/user-attachments/assets/f77e6ce6-951c-45c8-8631-5e8b9b064a4d" />

**수정 후**
<img width="909" height="97" alt="image" src="https://github.com/user-attachments/assets/c9f59300-5455-41dd-876b-c6e8127dd4a9" />

## 🔗 연관된 이슈

> closes #48 
