### PR TITLE
Feature: 공용 드롭다운 컴포넌트

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Input from './Input'
-import { useState, type ComponentProps } from 'react'
+import { useEffect, useRef, useState, type ComponentProps } from 'react'
 import { cn } from '@/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
@@ -53,17 +53,25 @@ function DropdownEmptyItem() {
 function Dropdown({ options }: DropdownProps) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
   const [selectedOption, setSelectedOption] = useState<string>('')
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const handleClickOption = (label: string) => {
     setSelectedOption(label)
     setIsOptionsOpen(false)
   }
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.value = selectedOption
+    }
+  }, [selectedOption])
+
   return (
     <div className="relative">
       <div className="relative h-fit">
         <Input
           className="cursor-pointer placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300"
+          ref={inputRef}
           onClick={() => setIsOptionsOpen((prev) => !prev)}
           readOnly
         />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from 'lucide-react'
 import Input from './Input'
+import { useState } from 'react'
 
 function DropdownItem({ option }) {
   return (
@@ -16,21 +17,29 @@ function DropdownEmptyItem() {
 }
 
 function Dropdown({ options = [] }) {
+  const [isOptionsOpen, setIsOptionsOpen] = useState(false)
+
   return (
     <div className="flex flex-col gap-1">
       <div className="relative h-fit">
-        <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
+        <Input
+          className="cursor-pointer placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300"
+          onClick={() => setIsOptionsOpen((prev) => !prev)}
+          readOnly
+        />
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
-      <div className="max-h-36 overflow-auto rounded-lg font-normal ring-1 ring-gray-300">
-        {options.length > 0 ? (
-          options.map((option, idx) => (
-            <DropdownItem key={idx} option={option} />
-          ))
-        ) : (
-          <DropdownEmptyItem />
-        )}
-      </div>
+      {isOptionsOpen && (
+        <div className="max-h-36 overflow-auto rounded-lg font-normal ring-1 ring-gray-300">
+          {options.length > 0 ? (
+            options.map((option, idx) => (
+              <DropdownItem key={idx} option={option} />
+            ))
+          ) : (
+            <DropdownEmptyItem />
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -20,7 +20,7 @@ function Dropdown({ options = [] }) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="relative">
       <div className="relative h-fit">
         <Input
           className="cursor-pointer placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300"
@@ -30,7 +30,7 @@ function Dropdown({ options = [] }) {
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       {isOptionsOpen && (
-        <div className="max-h-36 overflow-auto rounded-lg font-normal ring-1 ring-gray-300">
+        <div className="absolute top-13 z-10 max-h-36 w-full overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300">
           {options.length > 0 ? (
             options.map((option, idx) => (
               <DropdownItem key={idx} option={option} />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Input from './Input'
 import { useState } from 'react'
 import { cn } from '@/utils'
@@ -16,13 +16,19 @@ const dropdownItemVariants = cva(
   }
 )
 
-function DropdownItem({ option }) {
+interface DropdownItemProps {
+  option: { label: string; icon?: LucideIcon }
+}
+
+function DropdownItem({ option }: DropdownItemProps) {
+  const Icon = option.icon
+
   return (
     <div
       className={cn(dropdownItemVariants({ hasIcon: Boolean(option.icon) }))}
     >
       {option.label}
-      <option.icon className="absolute inset-y-0 left-2 my-auto h-4" />
+      {Icon && <Icon className="absolute inset-y-0 left-2 my-auto h-4" />}
     </div>
   )
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,11 +1,11 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Input from './Input'
-import { useState } from 'react'
+import { useState, type ComponentProps } from 'react'
 import { cn } from '@/utils'
-import { cva } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 const dropdownItemVariants = cva(
-  'relative cursor-pointer px-4 py-3 text-base hover:bg-gray-100',
+  'text-left w-full relative cursor-pointer px-4 py-3 text-base hover:bg-gray-100',
   {
     variants: {
       hasIcon: {
@@ -25,14 +25,20 @@ interface DropdownProps {
   options?: DropdownItemProps[]
 }
 
-function DropdownItem({ label, icon }: DropdownItemProps) {
+function DropdownItem({ label, icon, className, ...props }: DropdownItemProps) {
   const Icon = icon
 
   return (
-    <div className={cn(dropdownItemVariants({ hasIcon: Boolean(icon) }))}>
+    <button
+      className={cn(
+        dropdownItemVariants({ hasIcon: Boolean(icon) }),
+        className
+      )}
+      {...props}
+    >
       {label}
       {Icon && <Icon className="absolute inset-y-0 left-2 my-auto h-4" />}
-    </div>
+    </button>
   )
 }
 
@@ -44,6 +50,12 @@ function DropdownEmptyItem() {
 
 function Dropdown({ options }: DropdownProps) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
+  const [selectedOption, setSelectedOption] = useState<string>('')
+
+  const handleClickOption = (label: string) => {
+    setSelectedOption(label)
+    setIsOptionsOpen(false)
+  }
 
   return (
     <div className="relative">
@@ -56,10 +68,15 @@ function Dropdown({ options }: DropdownProps) {
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       {isOptionsOpen && (
-        <div className="absolute top-13 z-10 max-h-36 w-full overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
+        <div className="absolute top-13 z-10 flex max-h-36 w-full flex-col overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
           {options ? (
             options.map((option, idx) => (
-              <DropdownItem key={idx} label={option.label} icon={option.icon} />
+              <DropdownItem
+                key={idx}
+                label={option.label}
+                icon={option.icon}
+                onClick={() => handleClickOption(option.label)}
+              />
             ))
           ) : (
             <DropdownEmptyItem />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -79,7 +79,7 @@ function Dropdown({
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       {isOptionsOpen && (
-        <div className="animate-fade-in-translateY absolute top-13 z-10 flex max-h-36 w-full flex-col overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
+        <div className="animate-fade-in-translateY scrollbar-custom absolute top-13 z-10 flex max-h-36 w-full flex-col overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300">
           {options ? (
             options.map((option, idx) => (
               <DropdownItem

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -23,9 +23,13 @@ function Dropdown({ options = [] }) {
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       <div className="max-h-36 overflow-auto rounded-lg font-normal ring-1 ring-gray-300">
-        {options.map((option, idx) => (
-          <DropdownItem key={idx} option={option} />
-        ))}
+        {options.length > 0 ? (
+          options.map((option, idx) => (
+            <DropdownItem key={idx} option={option} />
+          ))
+        ) : (
+          <DropdownEmptyItem />
+        )}
       </div>
     </div>
   )

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Input from './Input'
-import { useRef, useState, type ComponentProps } from 'react'
+import { useState, type ComponentProps } from 'react'
 import { cn } from '@/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
@@ -55,20 +55,15 @@ function DropdownEmptyItem() {
 
 function Dropdown({
   options,
-  value,
+  value = '',
   onSelect,
   placeholder = '옵션을 선택하세요',
 }: DropdownProps) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
 
   const handleClickOption = (label: string) => {
     onSelect(label)
     setIsOptionsOpen(false)
-
-    if (inputRef.current) {
-      inputRef.current.value = label
-    }
   }
 
   return (
@@ -76,7 +71,7 @@ function Dropdown({
       <div className="relative h-fit">
         <Input
           className="cursor-pointer placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300"
-          ref={inputRef}
+          value={value}
           placeholder={placeholder}
           onClick={() => setIsOptionsOpen((prev) => !prev)}
           readOnly

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,19 @@
 import { ChevronDown } from 'lucide-react'
 import Input from './Input'
 import { useState } from 'react'
+import { cva } from 'class-variance-authority'
+
+const dropdownItemVariants = cva(
+  'relative cursor-pointer px-4 py-3 text-base hover:bg-gray-100',
+  {
+    variants: {
+      hasIcon: {
+        true: 'pl-10 pr-[17px]',
+        false: 'px-[17px]',
+      },
+    },
+  }
+)
 
 function DropdownItem({ option }) {
   return (

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -25,6 +25,9 @@ interface DropdownItemProps
 
 interface DropdownProps {
   options?: DropdownItemProps[]
+  value: string
+  onSelect: (value: string) => void
+  placeholder?: string
 }
 
 function DropdownItem({ label, icon, className, ...props }: DropdownItemProps) {

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -7,14 +7,18 @@ function DropdownItem({ option }) {
   )
 }
 
-function Dropdown() {
+function Dropdown({ options = [] }) {
   return (
     <div className="flex flex-col gap-1">
       <div className="relative h-fit">
         <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
-      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300"></div>
+      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
+        {options.map((option, idx) => (
+          <DropdownItem key={idx} option={option} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -17,17 +17,20 @@ const dropdownItemVariants = cva(
 )
 
 interface DropdownItemProps {
-  option: { label: string; icon?: LucideIcon }
+  label: string
+  icon?: LucideIcon
 }
 
-function DropdownItem({ option }: DropdownItemProps) {
-  const Icon = option.icon
+interface DropdownProps {
+  options?: DropdownItemProps[]
+}
+
+function DropdownItem({ label, icon }: DropdownItemProps) {
+  const Icon = icon
 
   return (
-    <div
-      className={cn(dropdownItemVariants({ hasIcon: Boolean(option.icon) }))}
-    >
-      {option.label}
+    <div className={cn(dropdownItemVariants({ hasIcon: Boolean(icon) }))}>
+      {label}
       {Icon && <Icon className="absolute inset-y-0 left-2 my-auto h-4" />}
     </div>
   )
@@ -39,7 +42,7 @@ function DropdownEmptyItem() {
   )
 }
 
-function Dropdown({ options = [] }) {
+function Dropdown({ options }: DropdownProps) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
 
   return (
@@ -54,9 +57,9 @@ function Dropdown({ options = [] }) {
       </div>
       {isOptionsOpen && (
         <div className="absolute top-13 z-10 max-h-36 w-full overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
-          {options.length > 0 ? (
+          {options ? (
             options.map((option, idx) => (
-              <DropdownItem key={idx} option={option} />
+              <DropdownItem key={idx} label={option.label} icon={option.icon} />
             ))
           ) : (
             <DropdownEmptyItem />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -50,21 +50,25 @@ function DropdownEmptyItem() {
   )
 }
 
-function Dropdown({ options }: DropdownProps) {
+function Dropdown({
+  options,
+  value,
+  onSelect,
+  placeholder = '옵션을 선택하세요',
+}: DropdownProps) {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false)
-  const [selectedOption, setSelectedOption] = useState<string>('')
   const inputRef = useRef<HTMLInputElement>(null)
 
   const handleClickOption = (label: string) => {
-    setSelectedOption(label)
+    onSelect(label)
     setIsOptionsOpen(false)
   }
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.value = selectedOption
+      inputRef.current.value = value
     }
-  }, [selectedOption])
+  }, [value])
 
   return (
     <div className="relative">
@@ -72,6 +76,7 @@ function Dropdown({ options }: DropdownProps) {
         <Input
           className="cursor-pointer placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300"
           ref={inputRef}
+          placeholder={placeholder}
           onClick={() => setIsOptionsOpen((prev) => !prev)}
           readOnly
         />

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -14,7 +14,7 @@ function Dropdown({ options = [] }) {
         <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
-      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
+      <div className="max-h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
         {options.map((option, idx) => (
           <DropdownItem key={idx} option={option} />
         ))}

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -16,7 +16,9 @@ const dropdownItemVariants = cva(
   }
 )
 
-interface DropdownItemProps {
+interface DropdownItemProps
+  extends ComponentProps<'button'>,
+    VariantProps<typeof dropdownItemVariants> {
   label: string
   icon?: LucideIcon
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from 'lucide-react'
 import Input from './Input'
 import { useState } from 'react'
+import { cn } from '@/utils'
 import { cva } from 'class-variance-authority'
 
 const dropdownItemVariants = cva(
@@ -17,8 +18,11 @@ const dropdownItemVariants = cva(
 
 function DropdownItem({ option }) {
   return (
-    <div className="cursor-pointer px-4 py-3 text-base hover:bg-gray-100">
-      {option}
+    <div
+      className={cn(dropdownItemVariants({ hasIcon: Boolean(option.icon) }))}
+    >
+      {option.label}
+      <option.icon className="absolute inset-y-0 left-2 my-auto h-4" />
     </div>
   )
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -3,7 +3,15 @@ import Input from './Input'
 
 function DropdownItem({ option }) {
   return (
-    <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">{option}</div>
+    <div className="cursor-pointer px-4 py-3 text-base hover:bg-gray-100">
+      {option}
+    </div>
+  )
+}
+
+function DropdownEmptyItem() {
+  return (
+    <div className="bg-gray-50 px-4 py-3 text-sm text-gray-300">옵션 없음</div>
   )
 }
 
@@ -14,7 +22,7 @@ function Dropdown({ options = [] }) {
         <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
-      <div className="max-h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
+      <div className="max-h-36 overflow-auto rounded-lg font-normal ring-1 ring-gray-300">
         {options.map((option, idx) => (
           <DropdownItem key={idx} option={option} />
         ))}

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,12 @@
 import { ChevronDown } from 'lucide-react'
 import Input from './Input'
 
+function DropdownItem({ option }) {
+  return (
+    <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">{option}</div>
+  )
+}
+
 function Dropdown() {
   return (
     <div className="flex flex-col gap-1">
@@ -8,12 +14,7 @@ function Dropdown() {
         <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
-      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
-        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션1</div>
-        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션2</div>
-        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션3</div>
-        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션4</div>
-      </div>
+      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300"></div>
     </div>
   )
 }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import Input from './Input'
-import { useEffect, useRef, useState, type ComponentProps } from 'react'
+import { useRef, useState, type ComponentProps } from 'react'
 import { cn } from '@/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
 
@@ -65,13 +65,11 @@ function Dropdown({
   const handleClickOption = (label: string) => {
     onSelect(label)
     setIsOptionsOpen(false)
-  }
 
-  useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.value = value
+      inputRef.current.value = label
     }
-  }, [value])
+  }
 
   return (
     <div className="relative">
@@ -86,7 +84,7 @@ function Dropdown({
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       {isOptionsOpen && (
-        <div className="absolute top-13 z-10 flex max-h-36 w-full flex-col overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
+        <div className="animate-fade-in-translateY absolute top-13 z-10 flex max-h-36 w-full flex-col overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
           {options ? (
             options.map((option, idx) => (
               <DropdownItem

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,21 @@
+import { ChevronDown } from 'lucide-react'
+import Input from './Input'
+
+function Dropdown() {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="relative h-fit">
+        <Input className="placeholder:text-gray-500 focus:ring-1 focus:ring-gray-300" />
+        <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
+      </div>
+      <div className="h-36 overflow-auto rounded-lg text-base font-normal ring-1 ring-gray-300">
+        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션1</div>
+        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션2</div>
+        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션3</div>
+        <div className="cursor-pointer px-4 py-3 hover:bg-gray-100">옵션4</div>
+      </div>
+    </div>
+  )
+}
+
+export default Dropdown

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -30,7 +30,7 @@ function Dropdown({ options = [] }) {
         <ChevronDown className="absolute inset-y-0 right-2 my-auto h-[14px]" />
       </div>
       {isOptionsOpen && (
-        <div className="absolute top-13 z-10 max-h-36 w-full overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300">
+        <div className="absolute top-13 z-10 max-h-36 w-full overflow-auto rounded-lg bg-white font-normal ring-1 ring-gray-300 [&::-webkit-scrollbar]:w-4 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-3 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-white [&::-webkit-scrollbar-thumb]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full">
           {options.length > 0 ? (
             options.map((option, idx) => (
               <DropdownItem key={idx} option={option} />

--- a/src/index.css
+++ b/src/index.css
@@ -55,3 +55,17 @@ body {
   --color-danger-600: #dc2626;
   --color-danger-800: #991b1b;
 }
+
+@theme {
+  --animate-fade-in-translateY: fade-in-translateY 0.3s ease-out;
+
+  @keyframes fade-in-translateY {
+    0% {
+      opacity: 0;
+      transform: translateY(-5%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -69,3 +69,19 @@ body {
     }
   }
 }
+
+@layer utilities {
+  .scrollbar-custom::-webkit-scrollbar {
+    width: 16px;
+  }
+  .scrollbar-custom::-webkit-scrollbar-track {
+    border-radius: 16px;
+  }
+  .scrollbar-custom::-webkit-scrollbar-thumb {
+    border-radius: 16px;
+  }
+  .scrollbar-custom::-webkit-scrollbar-thumb {
+    border: 3px solid #fff;
+    background-color: #f3f4f6;
+  }
+}


### PR DESCRIPTION
## 🚀 PR 요약

공용 드롭다운 컴포넌트를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 드롭다운 UI 추가
- 드롭다운 옵션 목록이 3개 이상인 경우, 3개 이하인 경우, 없는 경우의 스타일 지정
- 드롭다운 props 타입 정리
- 드롭다운 애니메이션 스타일 추가

### 참고 사항

- 드롭다운 컴포넌트의 props는 다음과 같습니다.
  - options - 드롭다운 옵션 리스트
  - onSelect - 선택된 옵션을 관리하는 state의 업데이트 함수
  - placeholder - 기본값: _옵션을 선택하세요_

- 드롭다운에 옵션 목록을 props로 전달할 때 다음과 같은 형태로 전달 부탁드립니다.
```
// 아이콘 X -> 각 객체 요소가 label을 포함

const DROPDOWN_THREE_SAMPLES = [
  { label: '사과' },
  { label: '바나나' },
  { label: '귤' },
]

<Dropdown options={DROPDOWN_THREE_SAMPLES} />

// 아이콘 O -> 각 객체 요소가 label, icon을 포함

import { Citrus } from 'lucide-react'

const DROPDOWN_ICON_SAMPLES = [
  { label: '사과', icon: Citrus },
  { label: '바나나', icon: Citrus },
  { label: '귤', icon: Citrus },
]

<Dropdown options={DROPDOWN_ICON_SAMPLES} />

```
- 드롭다운을 사용하실 때 선택된 옵션을 관리하는 state를 생성해서 드롭다운 컴포넌트로 전달해서 사용해주셔야 합니다.
```
const [selectedOption, setSelectedOption] = useState<string>('')

<Dropdown
  options={DROPDOWN_SAMPLES}
  value={selectedOption}
  onSelect={setSelectedOption}
/>
```

### 스크린 샷

![StudyHub-Chrome2025-09-0119-24-27-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6c400102-a89e-4b32-9836-9cd83968211c)

![StudyHub-Chrome2025-09-0119-26-56-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7eef398f-d060-4b2b-a459-2a56df524bd4)

## 🔗 연관된 이슈

> closes #24
