### PR TITLE
Fix: 모달 일부 기능 수정

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -35,10 +35,10 @@ interface ModalTriggerProps extends ComponentProps<'div'> {
 }
 
 function ModalTrigger({ children, className, ...props }: ModalTriggerProps) {
-  const { open } = useModalContext()
+  const { toggle } = useModalContext()
   return (
     <div
-      onClick={open}
+      onClick={toggle}
       {...props}
       className={cn('hover:cursor-pointer', className)}
     >

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -34,10 +34,14 @@ interface ModalTriggerProps extends ComponentProps<'div'> {
   children: ReactNode
 }
 
-function ModalTrigger({ children, ...props }: ModalTriggerProps) {
+function ModalTrigger({ children, className, ...props }: ModalTriggerProps) {
   const { open } = useModalContext()
   return (
-    <div onClick={open} {...props} className="hover:cursor-pointer">
+    <div
+      onClick={open}
+      {...props}
+      className={cn('hover:cursor-pointer', className)}
+    >
       {children}
     </div>
   )
@@ -51,10 +55,14 @@ interface ModalCloseProps extends ComponentProps<'div'> {
   children: ReactNode
 }
 
-function ModalClose({ children, ...props }: ModalCloseProps) {
+function ModalClose({ children, className, ...props }: ModalCloseProps) {
   const { close } = useModalContext()
   return (
-    <div onClick={close} {...props} className="hover:cursor-pointer">
+    <div
+      onClick={close}
+      {...props}
+      className={cn('hover:cursor-pointer', className)}
+    >
       {children}
     </div>
   )

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -34,10 +34,10 @@ interface ModalTriggerProps extends ComponentProps<'div'> {
   children: ReactNode
 }
 
-function ModalTrigger({ children, ...rest }: ModalTriggerProps) {
+function ModalTrigger({ children, ...props }: ModalTriggerProps) {
   const { open } = useModalContext()
   return (
-    <div onClick={open} {...rest} className="hover:cursor-pointer">
+    <div onClick={open} {...props} className="hover:cursor-pointer">
       {children}
     </div>
   )
@@ -51,10 +51,10 @@ interface ModalCloseProps extends ComponentProps<'div'> {
   children: ReactNode
 }
 
-function ModalClose({ children, ...rest }: ModalCloseProps) {
+function ModalClose({ children, ...props }: ModalCloseProps) {
   const { close } = useModalContext()
   return (
-    <div onClick={close} {...rest} className="hover:cursor-pointer">
+    <div onClick={close} {...props} className="hover:cursor-pointer">
       {children}
     </div>
   )
@@ -154,7 +154,7 @@ interface ModalContentProps extends ComponentProps<'div'> {
   children: ReactNode
 }
 
-function ModalContent({ children, className, ...rest }: ModalContentProps) {
+function ModalContent({ children, className, ...props }: ModalContentProps) {
   const { isOpen, close } = useModalContext()
   const [show, setShow] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
@@ -205,7 +205,7 @@ function ModalContent({ children, className, ...rest }: ModalContentProps) {
           isAnimating ? 'scale-100 opacity-100' : 'scale-95 opacity-0',
           className
         )}
-        {...rest}
+        {...props}
       >
         {children}
       </div>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -160,9 +160,15 @@ const MODAL_ANIMATION_TIME_MS = 120
 
 interface ModalContentProps extends ComponentProps<'div'> {
   children: ReactNode
+  isPositionCenter?: boolean
 }
 
-function ModalContent({ children, className, ...props }: ModalContentProps) {
+function ModalContent({
+  children,
+  className,
+  isPositionCenter = true,
+  ...props
+}: ModalContentProps) {
   const { isOpen } = useModalContext()
   const [show, setShow] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
@@ -186,7 +192,10 @@ function ModalContent({ children, className, ...props }: ModalContentProps) {
       {/* Modal */}
       <div
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 flex min-w-64 -translate-x-1/2 -translate-y-1/2 transform flex-col rounded-xl bg-white transition-all',
+          'fixed z-50 flex min-w-64 transform flex-col rounded-xl bg-white transition-all',
+          isPositionCenter
+            ? 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'
+            : '',
           `duration-[${MODAL_ANIMATION_TIME_MS}]`,
           isAnimating ? 'scale-100 opacity-100' : 'scale-95 opacity-0',
           className

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -170,12 +170,10 @@ function ModalContent({
   ...props
 }: ModalContentProps) {
   const { isOpen } = useModalContext()
-  const [show, setShow] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
 
   useEffect(() => {
     if (isOpen) {
-      setShow(true)
       const timer = setTimeout(
         () => setIsAnimating(true),
         MODAL_ANIMATION_TIME_MS
@@ -183,8 +181,6 @@ function ModalContent({
       return () => clearTimeout(timer)
     }
     setIsAnimating(false)
-    const timer = setTimeout(() => setShow(false), MODAL_ANIMATION_TIME_MS) // Delay unmount for animation
-    return () => clearTimeout(timer)
   }, [isOpen])
 
   return (


### PR DESCRIPTION
## 🚀 PR 요약

> 모달 일부 기능 수정

## ✏️ 변경 유형

- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드 리팩토링
- chore: 기타 변경사항

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- ModalTrigger와 ModalClose에 className prop 추가
- ModalOverlay on/off 기능
- ModalTrigger가 Modal을 키는 것 뿐만 아니라 토글
- ModalContent에 isPositionCenter prop 추가
  - 기존 방식에는 외부 className으로 left나 bottom 넣으면 충돌 발생
  - 중앙이 아니라 다른 위치에 모달을 위치하고 싶으면  isPositionCenter를 false로 하고 className 입력

### 참고 사항

- 예시코드
```typescript
function App() {
  return (
    <>
      <Modal isOverlay={false}>
        <ModalTrigger className="fixed right-2.5 bottom-2.5">
          <Button className="size-16 rounded-full">채팅</Button>
        </ModalTrigger>
        <ModalContent
          isPositionCenter={false}
          className="right-2.5 bottom-20 h-96 w-96 shadow"
        >
          <ModalHeader>
            <ModalTitle>채팅</ModalTitle>
          </ModalHeader>
          <ModalMain>하이</ModalMain>
        </ModalContent>
      </Modal>
      <Header />
      <LandingPage />
    </>
  )
}
```

### 스크린 샷


https://github.com/user-attachments/assets/01d866b6-aaae-4533-a286-8f3026ff931a


## 🔗 연관된 이슈

> closes #64
