### PR TITLE
Feature: 공통 스켈레톤 UI 추가

### DIFF
--- a/src/components/common/Skeleton/AvatarSkeleton.tsx
+++ b/src/components/common/Skeleton/AvatarSkeleton.tsx
@@ -2,17 +2,17 @@ import { cn } from '@/utils'
 import { Circle } from './SkeletonItem'
 
 const AVATAR_SIZE = {
-  XS: 'w-6',
-  SM: 'w-8',
-  MD: 'w-10',
-  LG: 'w-12',
-  XL: 'w-14',
+  xs: 'w-6',
+  sm: 'w-8',
+  md: 'w-10',
+  lg: 'w-12',
+  xl: 'w-14',
 }
 
 function AvatarSkeleton({
-  size = 'MD',
+  size = 'md',
 }: {
-  size?: 'XS' | 'SM' | 'MD' | 'LG' | 'XL'
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 }) {
   const w = AVATAR_SIZE[size]
 

--- a/src/components/common/Skeleton/AvatarSkeleton.tsx
+++ b/src/components/common/Skeleton/AvatarSkeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/utils'
+import { Circle } from './SkeletonItem'
+
+const AVATAR_SIZE = {
+  XS: 'w-6',
+  SM: 'w-8',
+  MD: 'w-10',
+  LG: 'w-12',
+  XL: 'w-14',
+}
+
+function AvatarSkeleton({
+  size = 'MD',
+}: {
+  size?: 'XS' | 'SM' | 'MD' | 'LG' | 'XL'
+}) {
+  const w = AVATAR_SIZE[size]
+
+  return (
+    <div className={cn(w)}>
+      <Circle />
+    </div>
+  )
+}
+
+export default AvatarSkeleton

--- a/src/components/common/Skeleton/ImageCardSkeleton.tsx
+++ b/src/components/common/Skeleton/ImageCardSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Rectangle, Sentence } from './SkeletonItem'
+
+function ImageCardSkeleton() {
+  return (
+    <div className="flex w-full flex-col items-center gap-2 overflow-hidden rounded-[12px] border border-solid border-gray-300">
+      <Rectangle width={100} height={60} isRounded={false} />
+      <div className="w-full flex-3 space-y-2 p-5 sm:space-y-6">
+        <Sentence />
+        <Sentence />
+        <Sentence />
+        <Rectangle width={100} height={25} />
+      </div>
+    </div>
+  )
+}
+
+export default ImageCardSkeleton

--- a/src/components/common/Skeleton/ListItemSkeleton.tsx
+++ b/src/components/common/Skeleton/ListItemSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Rectangle, Sentence } from './SkeletonItem'
+
+function ListItemSkeleton() {
+  return (
+    <div className="flex w-full items-center gap-2 border border-solid border-gray-300 p-[25px]">
+      <div className="flex-1">
+        <Rectangle width={100} height={50} />
+      </div>
+      <div className="w-full flex-3 space-y-2">
+        <Sentence />
+        <Sentence width={50} />
+        <Sentence width={50} />
+        <Sentence width={75} />
+      </div>
+    </div>
+  )
+}
+
+export default ListItemSkeleton

--- a/src/components/common/Skeleton/SkeletonItem.tsx
+++ b/src/components/common/Skeleton/SkeletonItem.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/utils'
+
+const skeletonStyle =
+  'text-gray-200 animate-shimmer bg-gradient-custom bg-[length:300%_100%]'
+
+export function Circle() {
+  return (
+    <svg
+      viewBox={'0 0 100 100'}
+      className={cn(skeletonStyle, 'rounded-full')}
+    ></svg>
+  )
+}
+
+export function Rectangle({
+  width = 100,
+  height = 100,
+  isRounded = true,
+}: {
+  width?: number
+  height?: number
+  isRounded?: boolean
+}) {
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn('w-full', skeletonStyle, isRounded && 'rounded-sm')}
+    ></svg>
+  )
+}
+
+export function Sentence({ width = 100 }: { width?: number }) {
+  return (
+    <svg
+      viewBox={`0 0 100 4`}
+      className={cn(`w-[${width}%]`, skeletonStyle, 'rounded-sm')}
+    ></svg>
+  )
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,9 +12,9 @@ import ToastContainer from '@/components/common/Toast/ToastContainer'
 import RootLayout from '@/components/layout/RootLayout'
 import MyPageLayout from '@/components/layout/MyPageLayout'
 import Chat from '@/components/chat/Chat'
-import ListItemSkeleton from './common/Skeleton/ListItemSkeleton'
-import ImageCardSkeleton from './common/Skeleton/ImageCardSkeleton'
-import AvatarSkeleton from './common/Skeleton/AvatarSkeleton'
+import ListItemSkeleton from '@/components/common/Skeleton/ListItemSkeleton'
+import ImageCardSkeleton from '@/components/common/Skeleton/ImageCardSkeleton'
+import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
 
 export {
   Badge,

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,6 +12,9 @@ import ToastContainer from '@/components/common/Toast/ToastContainer'
 import RootLayout from '@/components/layout/RootLayout'
 import MyPageLayout from '@/components/layout/MyPageLayout'
 import Chat from '@/components/chat/Chat'
+import ListItemSkeleton from './common/Skeleton/ListItemSkeleton'
+import ImageCardSkeleton from './common/Skeleton/ImageCardSkeleton'
+import AvatarSkeleton from './common/Skeleton/AvatarSkeleton'
 
 export {
   Badge,
@@ -27,4 +30,7 @@ export {
   RootLayout,
   Chat,
   MyPageLayout,
+  ListItemSkeleton,
+  ImageCardSkeleton,
+  AvatarSkeleton,
 }

--- a/src/index.css
+++ b/src/index.css
@@ -91,6 +91,26 @@ body {
   }
 }
 
+@theme {
+  --animate-shimmer: shimmer 3.5s infinite linear;
+
+  @keyframes shimmer {
+    0% {
+      background-position: 300% 0;
+    }
+    100% {
+      background-position: -300% 0;
+    }
+  }
+
+  --background-image-gradient-custom: linear-gradient(
+    to right,
+    #e5e7eb 0%,
+    #f3f4f6 50%,
+    #e5e7eb 100%
+  );
+}
+
 @layer utilities {
   .scrollbar-custom::-webkit-scrollbar {
     width: 16px;


### PR DESCRIPTION
## 🚀 PR 요약

공통 스켈레톤 로더 3가지를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 북마크한 공고, 북마크한 강의, 지원 내역에 적용할 ListItemSkeleton 추가
- 완료된 스터디에 적용할 ImageCardSkeleton 추가
- 프로필 사진에 적용할 AvatarSkeleton 추가
  - 사이즈는 공용 아바타 컴포넌트의 5가지 사이즈로 지정

### 참고 사항
- 적용하실 때 참고하시라고 아래 gif에서 UI 테스트할 때 사용한 테스트 코드 첨부하겠습니다.
```
<div className="flex flex-col gap-5 p-10">
  <h2 className="pt-10 text-2xl font-bold">
    * ListItemSkeleton - 북마크한 공고, 북마크한 강의, 지원 내역
  </h2>
  <ListItemSkeleton />
  <h2 className="pt-10 text-2xl font-bold">
    * ImageCardSkeleton - 완료된 스터디
  </h2>
  <div className="grid grid-cols-2 gap-2">
    <ImageCardSkeleton />
    <ImageCardSkeleton />
    <ImageCardSkeleton />
    <ImageCardSkeleton />
  </div>
  <h2 className="pt-10 text-2xl font-bold">
    * AvatarSkeleton - 프로필 사진
  </h2>
  <div className="flex items-center gap-2">
    <AvatarSkeleton size="XS" />
    <AvatarSkeleton size="SM" />
    <AvatarSkeleton />
    <AvatarSkeleton size="LG" />
    <AvatarSkeleton size="XL" />
  </div>
</div>
```

### 스크린 샷

**UI 테스트**
![StudyHub-Chrome2025-09-0417-13-38-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/274efea0-bd24-4271-9f90-f2b053c402b7)

**모바일 화면 테스트**
<img width="300" height="2280" alt="localhost_5173_(iPhone SE)" src="https://github.com/user-attachments/assets/140d0f9f-1906-494e-b39f-bf77fe8aee80" />

## 🔗 연관된 이슈

> closes #70 
