### PR TITLE
Feature:  공용 아바타 컴포넌트 생성

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,18 +1,13 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 import type { ComponentProps } from 'react'
 import { cn } from '@/utils'
+import { AVATAR_SIZE } from '@/components'
 
 const AvatarImage = cva(
   'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center border-primary-200 border',
   {
     variants: {
-      size: {
-        xs: 'size-6',
-        sm: 'size-8',
-        md: 'size-10',
-        lg: 'size-12',
-        xl: 'size-16',
-      },
+      size: AVATAR_SIZE,
     },
     defaultVariants: {
       size: 'md',

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 import type { ComponentProps } from 'react'
 import { cn } from '@/utils'
-import { AVATAR_SIZE } from '@/components'
+import { AVATAR_SIZE } from './AvatarSize'
 
 const AvatarImage = cva(
   'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center border-primary-200 border',

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 import type { ComponentProps } from 'react'
 import { cn } from '@/utils'
-import { AVATAR_SIZE } from './AvatarSize'
+import { AVATAR_SIZE } from '@/components/avatar/AvatarSize'
 
 const AvatarImage = cva(
   'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center border-primary-200 border',
@@ -49,7 +49,11 @@ export default function Avatar({
   return (
     <div className={cn(AvatarImage({ size }), className)}>
       {src ? (
-        <img src={src} className="h-full w-full rounded-full object-cover" />
+        <img
+          src={src}
+          alt={alt}
+          className="h-full w-full rounded-full object-cover"
+        />
       ) : (
         <span>{alt?.charAt(0) || '김'}</span>
         // 첫번째 글자만 가져와서 혹은 '김'으로 이미지 대체

--- a/src/components/avatar/AvatarSize.ts
+++ b/src/components/avatar/AvatarSize.ts
@@ -1,0 +1,8 @@
+export const AVATAR_SIZE = {
+  xs: 'size-6',
+  sm: 'size-8',
+  md: 'size-10',
+  lg: 'size-12',
+  xl: 'size-16',
+} as const
+// 상수는 절대경로 사용이 권장되지 않기에 index.tsx 설정은 제외함.

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,0 +1,65 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ComponentProps } from 'react'
+import { cn } from '@/utils'
+
+const AvatarImage = cva(
+  'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center border-primary-200 border',
+  {
+    variants: {
+      size: {
+        xs: 'size-6',
+        sm: 'size-8',
+        md: 'size-10',
+        lg: 'size-12',
+        xl: 'size-16',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
+
+const AvatarState = cva(
+  'size-3 absolute bottom-0 right-0 rounded-full opacity-80',
+  {
+    variants: {
+      state: {
+        active: 'bg-success-500',
+        away: 'bg-primary-500',
+        dnd: 'bg-danger-500',
+        offline: 'bg-gray-400',
+      },
+    },
+    defaultVariants: {
+      state: 'active',
+    },
+  }
+)
+
+interface AvatarProps
+  extends ComponentProps<'img'>,
+    VariantProps<typeof AvatarImage>,
+    VariantProps<typeof AvatarState> {
+  alt: string
+}
+
+export default function Avatar({
+  alt,
+  size,
+  state,
+  className,
+  src,
+}: AvatarProps) {
+  return (
+    <div className={cn(AvatarImage({ size }), className)}>
+      {src ? (
+        <img src={src} className="h-full w-full rounded-full object-cover" />
+      ) : (
+        <span>{alt?.charAt(0) || '김'}</span>
+        // 첫번째 글자만 가져와서 혹은 '김'으로 이미지 대체
+      )}
+      <span aria-hidden="true" className={cn(AvatarState({ state }))} />
+    </div>
+  )
+}

--- a/src/components/common/Skeleton/AvatarSkeleton.tsx
+++ b/src/components/common/Skeleton/AvatarSkeleton.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils'
 import { Circle } from './SkeletonItem'
-import { AVATAR_SIZE } from '@/components'
+import { AVATAR_SIZE } from '@/components/avatar/AvatarSize'
 
 function AvatarSkeleton({
   size = 'md',

--- a/src/components/common/Skeleton/AvatarSkeleton.tsx
+++ b/src/components/common/Skeleton/AvatarSkeleton.tsx
@@ -1,13 +1,6 @@
 import { cn } from '@/utils'
 import { Circle } from './SkeletonItem'
-
-const AVATAR_SIZE = {
-  xs: 'w-6',
-  sm: 'w-8',
-  md: 'w-10',
-  lg: 'w-12',
-  xl: 'w-14',
-}
+import { AVATAR_SIZE } from '@/components'
 
 function AvatarSkeleton({
   size = 'md',

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,9 +12,12 @@ import ToastContainer from '@/components/common/Toast/ToastContainer'
 import RootLayout from '@/components/layout/RootLayout'
 import MyPageLayout from '@/components/layout/MyPageLayout'
 import Chat from '@/components/chat/Chat'
+
 import ListItemSkeleton from '@/components/common/Skeleton/ListItemSkeleton'
 import ImageCardSkeleton from '@/components/common/Skeleton/ImageCardSkeleton'
 import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
+
+import Avatar from '@/components/common/Avatar'
 
 export {
   Badge,
@@ -33,4 +36,5 @@ export {
   ListItemSkeleton,
   ImageCardSkeleton,
   AvatarSkeleton,
+  Avatar,
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,12 +12,10 @@ import ToastContainer from '@/components/common/Toast/ToastContainer'
 import RootLayout from '@/components/layout/RootLayout'
 import MyPageLayout from '@/components/layout/MyPageLayout'
 import Chat from '@/components/chat/Chat'
-
 import ListItemSkeleton from '@/components/common/Skeleton/ListItemSkeleton'
 import ImageCardSkeleton from '@/components/common/Skeleton/ImageCardSkeleton'
 import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
-
-import Avatar from '@/components/common/Avatar'
+import Avatar from '@/components/avatar/Avatar'
 
 export {
   Badge,


### PR DESCRIPTION
## 🚀 PR 요약

> 뱃지 컴포넌트 형식을 참고하여 아바타 컴포넌트를 생성했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

### 작업 사항

- 공용 아바타 컴포넌트 생성
- 스켈레톤 브랜치 머지된 후 리베이스 하여 공통으로 사용하는 아바타 사이즈 상수 분리.

### 참고 사항

-  아바타 사이즈 상수는 절대경로 사용이 바람직하지 않다고 하여 미지정.

### 스크린 샷

<img width="58" height="61" alt="아바타" src="https://github.com/user-attachments/assets/13bb393b-ec2b-4321-9902-8cf25759d0c2" />

## 🔗 연관된 이슈

> closes #42 
