### PR TITLE
Feature: 조건부 렌더링용 화면 상태 UI 추가

### DIFF
--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -3,7 +3,7 @@ import Button from '@/components/common/Button'
 import { cn } from '@/utils'
 import type { ReactNode } from 'react'
 
-interface BaseStateProps {
+interface BaseStateProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: LucideIcon
   iconColor?: string
   iconBg?: string
@@ -44,9 +44,17 @@ function BaseState({
   buttonType,
   buttonClassName,
   onClick,
+  className,
+  ...props
 }: BaseStateProps) {
   return (
-    <div className="flex size-full flex-col items-center justify-center gap-6 rounded-lg border border-solid border-gray-200 bg-gray-50">
+    <div
+      className={cn(
+        'flex size-full flex-col items-center justify-center gap-6 rounded-lg border border-solid border-gray-200 bg-gray-50',
+        className
+      )}
+      {...props}
+    >
       {icon ? (
         <Icon icon={icon} iconColor={iconColor} iconBg={iconBg} />
       ) : (

--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -61,8 +61,12 @@ function BaseState({
         <Spinner />
       )}
       <div className="flex flex-col items-center justify-center gap-2">
-        <h4 className="text-xl font-semibold text-gray-900">{title}</h4>
-        <p className="text-base/6 font-normal text-gray-500">{description}</p>
+        <h4 className="text:lg font-semibold text-gray-900 sm:text-xl">
+          {title}
+        </h4>
+        <p className="text-sm/6 font-normal text-gray-500 sm:text-base/6">
+          {description}
+        </p>
       </div>
       {buttonValue && (
         <Button

--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -1,84 +1,111 @@
 import { type LucideIcon } from 'lucide-react'
 import Button from '@/components/common/Button'
 import { cn } from '@/utils'
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 
-interface BaseStateProps extends React.HTMLAttributes<HTMLDivElement> {
+interface BaseStateIconProps extends ComponentProps<'div'> {
   icon?: LucideIcon
   iconColor?: string
   iconBg?: string
-  title?: string
-  description?: string
-  buttonValue?: ReactNode
-  buttonType?: 'primary' | 'outline'
-  buttonClassName?: string
-  onClick?: () => void
 }
 
-function Icon({ icon: CurrentIcon, iconBg, iconColor }: BaseStateProps) {
+function BaseStateIcon({
+  icon: CurrentIcon,
+  iconBg,
+  iconColor,
+  className,
+  ...props
+}: BaseStateIconProps) {
   return (
     <div
       className={cn(
         'flex size-20 items-center justify-center rounded-full',
-        iconBg
+        iconBg,
+        className
       )}
+      {...props}
     >
       {CurrentIcon && <CurrentIcon className={cn('size-[30px]', iconColor)} />}
     </div>
   )
 }
 
-function Spinner() {
+function BaseStateSpinner({ className, ...props }: ComponentProps<'div'>) {
   return (
-    <div className="border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid" />
+    <div
+      className={cn(
+        'border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid',
+        className
+      )}
+      {...props}
+    />
   )
 }
 
-function BaseState({
-  icon,
-  iconColor,
-  iconBg,
-  title = '',
-  description = '',
-  buttonValue,
-  buttonType,
-  buttonClassName,
-  onClick,
+interface BaseStateContentProps extends ComponentProps<'div'> {
+  title: string
+  description: string
+}
+
+function BaseStateContent({
+  title,
+  description,
   className,
   ...props
-}: BaseStateProps) {
+}: BaseStateContentProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-2',
+        className
+      )}
+      {...props}
+    >
+      <h4 className="text:lg font-semibold text-gray-900 sm:text-xl">
+        {title}
+      </h4>
+      <p className="text-sm/6 font-normal text-gray-500 sm:text-base/6">
+        {description}
+      </p>
+    </div>
+  )
+}
+
+interface BaseStateButtonProps extends ComponentProps<'button'> {
+  buttonVariant: 'primary' | 'outline'
+  buttonContent: ReactNode
+}
+
+function BaseStateButton({
+  buttonVariant,
+  buttonContent,
+  className,
+  ...props
+}: BaseStateButtonProps) {
+  return (
+    <Button variant={buttonVariant} className={className} {...props}>
+      {buttonContent}
+    </Button>
+  )
+}
+
+function BaseStateWrapper({ className, children }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
         'flex size-full flex-col items-center justify-center gap-6 rounded-lg border border-solid border-gray-200 bg-gray-50',
         className
       )}
-      {...props}
     >
-      {icon ? (
-        <Icon icon={icon} iconColor={iconColor} iconBg={iconBg} />
-      ) : (
-        <Spinner />
-      )}
-      <div className="flex flex-col items-center justify-center gap-2">
-        <h4 className="text:lg font-semibold text-gray-900 sm:text-xl">
-          {title}
-        </h4>
-        <p className="text-sm/6 font-normal text-gray-500 sm:text-base/6">
-          {description}
-        </p>
-      </div>
-      {buttonValue && (
-        <Button
-          variant={buttonType}
-          className={buttonClassName}
-          onClick={onClick}
-        >
-          {buttonValue}
-        </Button>
-      )}
+      {children}
     </div>
   )
 }
 
-export default BaseState
+export {
+  BaseStateIcon,
+  BaseStateSpinner,
+  BaseStateContent,
+  BaseStateButton,
+  BaseStateWrapper,
+}

--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -7,8 +7,8 @@ interface BaseStateProps {
   icon?: LucideIcon
   iconColor?: string
   iconBg?: string
-  title: string
-  description: string
+  title?: string
+  description?: string
   buttonValue?: ReactNode
   buttonType?: 'primary' | 'outline'
   buttonClassName?: string
@@ -38,8 +38,8 @@ function BaseState({
   icon,
   iconColor,
   iconBg,
-  title,
-  description,
+  title = '',
+  description = '',
   buttonValue,
   buttonType,
   buttonClassName,

--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -15,8 +15,27 @@ interface BaseStateProps {
   onClick?: () => void
 }
 
+function Icon({ icon: CurrentIcon, iconBg, iconColor }: BaseStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex size-20 items-center justify-center rounded-full',
+        iconBg
+      )}
+    >
+      {CurrentIcon && <CurrentIcon className={cn('size-[30px]', iconColor)} />}
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div className="border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid" />
+  )
+}
+
 function BaseState({
-  icon: Icon,
+  icon,
   iconColor,
   iconBg,
   title,
@@ -28,17 +47,10 @@ function BaseState({
 }: BaseStateProps) {
   return (
     <div className="flex size-full flex-col items-center justify-center gap-6 rounded-lg border border-solid border-gray-200 bg-gray-50">
-      {Icon ? (
-        <div
-          className={cn(
-            'flex size-20 items-center justify-center rounded-full',
-            iconBg
-          )}
-        >
-          <Icon className={cn('size-[30px]', iconColor)} />
-        </div>
+      {icon ? (
+        <Icon icon={icon} iconColor={iconColor} iconBg={iconBg} />
       ) : (
-        <div className="border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid" />
+        <Spinner />
       )}
       <div className="flex flex-col items-center justify-center gap-2">
         <h4 className="text-xl font-semibold text-gray-900">{title}</h4>

--- a/src/components/common/State/BaseState.tsx
+++ b/src/components/common/State/BaseState.tsx
@@ -1,0 +1,60 @@
+import { type LucideIcon } from 'lucide-react'
+import Button from '@/components/common/Button'
+import { cn } from '@/utils'
+import type { ReactNode } from 'react'
+
+interface BaseStateProps {
+  icon?: LucideIcon
+  iconColor?: string
+  iconBg?: string
+  title: string
+  description: string
+  buttonValue?: ReactNode
+  buttonType?: 'primary' | 'outline'
+  buttonClassName?: string
+  onClick?: () => void
+}
+
+function BaseState({
+  icon: Icon,
+  iconColor,
+  iconBg,
+  title,
+  description,
+  buttonValue,
+  buttonType,
+  buttonClassName,
+  onClick,
+}: BaseStateProps) {
+  return (
+    <div className="flex size-full flex-col items-center justify-center gap-6 rounded-lg border border-solid border-gray-200 bg-gray-50">
+      {Icon ? (
+        <div
+          className={cn(
+            'flex size-20 items-center justify-center rounded-full',
+            iconBg
+          )}
+        >
+          <Icon className={cn('size-[30px]', iconColor)} />
+        </div>
+      ) : (
+        <div className="border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid" />
+      )}
+      <div className="flex flex-col items-center justify-center gap-2">
+        <h4 className="text-xl font-semibold text-gray-900">{title}</h4>
+        <p className="text-base/6 font-normal text-gray-500">{description}</p>
+      </div>
+      {buttonValue && (
+        <Button
+          variant={buttonType}
+          className={buttonClassName}
+          onClick={onClick}
+        >
+          {buttonValue}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default BaseState

--- a/src/components/common/State/EmptyDataState.tsx
+++ b/src/components/common/State/EmptyDataState.tsx
@@ -26,7 +26,7 @@ function EmptyDataState({ onClick, className, ...props }: EmptyDataStateProps) {
       <BaseStateButton
         buttonContent={
           <span className="flex items-center gap-2">
-            <Plus className="size-4" />
+            <Plus aria-hidden="true" className="size-4" />
             새로 만들기
           </span>
         }

--- a/src/components/common/State/EmptyDataState.tsx
+++ b/src/components/common/State/EmptyDataState.tsx
@@ -1,7 +1,11 @@
 import { Inbox, Plus } from 'lucide-react'
 import BaseState from './BaseState'
 
-function EmptyDataState({ onClick }: { onClick?: () => void }) {
+interface EmptyDataStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  onClick?: () => void
+}
+
+function EmptyDataState({ onClick, className, ...props }: EmptyDataStateProps) {
   return (
     <BaseState
       icon={Inbox}
@@ -18,6 +22,8 @@ function EmptyDataState({ onClick }: { onClick?: () => void }) {
       buttonType="primary"
       buttonClassName="px-6 py-3"
       onClick={onClick}
+      className={className}
+      {...props}
     />
   )
 }

--- a/src/components/common/State/EmptyDataState.tsx
+++ b/src/components/common/State/EmptyDataState.tsx
@@ -1,0 +1,25 @@
+import { Inbox, Plus } from 'lucide-react'
+import BaseState from './BaseState'
+
+function EmptyDataState({ onClick }: { onClick?: () => void }) {
+  return (
+    <BaseState
+      icon={Inbox}
+      iconColor="text-primary-500"
+      iconBg="bg-primary-50"
+      title="아직 데이터가 없습니다"
+      description="첫 번째 항목을 추가해보세요"
+      buttonValue={
+        <span className="flex items-center gap-2">
+          <Plus className="size-4" />
+          새로 만들기
+        </span>
+      }
+      buttonType="primary"
+      buttonClassName="px-6 py-3"
+      onClick={onClick}
+    />
+  )
+}
+
+export default EmptyDataState

--- a/src/components/common/State/EmptyDataState.tsx
+++ b/src/components/common/State/EmptyDataState.tsx
@@ -1,30 +1,40 @@
 import { Inbox, Plus } from 'lucide-react'
-import BaseState from './BaseState'
+import {
+  BaseStateButton,
+  BaseStateContent,
+  BaseStateIcon,
+  BaseStateWrapper,
+} from './BaseState'
+import type { ComponentProps } from 'react'
 
-interface EmptyDataStateProps extends React.HTMLAttributes<HTMLDivElement> {
+interface EmptyDataStateProps extends ComponentProps<typeof BaseStateWrapper> {
   onClick?: () => void
 }
 
 function EmptyDataState({ onClick, className, ...props }: EmptyDataStateProps) {
   return (
-    <BaseState
-      icon={Inbox}
-      iconColor="text-primary-500"
-      iconBg="bg-primary-50"
-      title="아직 데이터가 없습니다"
-      description="첫 번째 항목을 추가해보세요"
-      buttonValue={
-        <span className="flex items-center gap-2">
-          <Plus className="size-4" />
-          새로 만들기
-        </span>
-      }
-      buttonType="primary"
-      buttonClassName="px-6 py-3"
-      onClick={onClick}
-      className={className}
-      {...props}
-    />
+    <BaseStateWrapper className={className} {...props}>
+      <BaseStateIcon
+        icon={Inbox}
+        iconColor="text-primary-500"
+        iconBg="bg-primary-50"
+      />
+      <BaseStateContent
+        title="아직 데이터가 없습니다"
+        description="첫 번째 항목을 추가해보세요"
+      />
+      <BaseStateButton
+        buttonContent={
+          <span className="flex items-center gap-2">
+            <Plus className="size-4" />
+            새로 만들기
+          </span>
+        }
+        buttonVariant="primary"
+        className="px-6 py-3"
+        onClick={onClick}
+      />
+    </BaseStateWrapper>
   )
 }
 

--- a/src/components/common/State/EmptyResultState.tsx
+++ b/src/components/common/State/EmptyResultState.tsx
@@ -1,7 +1,15 @@
 import { Search } from 'lucide-react'
 import BaseState from './BaseState'
 
-function EmptyResultState({ onClick }: { onClick?: () => void }) {
+interface EmptyResultStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  onClick?: () => void
+}
+
+function EmptyResultState({
+  onClick,
+  className,
+  ...props
+}: EmptyResultStateProps) {
   return (
     <BaseState
       icon={Search}
@@ -13,6 +21,8 @@ function EmptyResultState({ onClick }: { onClick?: () => void }) {
       buttonType="outline"
       buttonClassName="bg-gray-50 text-gray-700 transition-colors duration-300 ease-out hover:bg-gray-200"
       onClick={onClick}
+      className={className}
+      {...props}
     />
   )
 }

--- a/src/components/common/State/EmptyResultState.tsx
+++ b/src/components/common/State/EmptyResultState.tsx
@@ -1,7 +1,14 @@
 import { Search } from 'lucide-react'
-import BaseState from './BaseState'
+import {
+  BaseStateButton,
+  BaseStateContent,
+  BaseStateIcon,
+  BaseStateWrapper,
+} from './BaseState'
+import type { ComponentProps } from 'react'
 
-interface EmptyResultStateProps extends React.HTMLAttributes<HTMLDivElement> {
+interface EmptyResultStateProps
+  extends ComponentProps<typeof BaseStateWrapper> {
   onClick?: () => void
 }
 
@@ -11,19 +18,23 @@ function EmptyResultState({
   ...props
 }: EmptyResultStateProps) {
   return (
-    <BaseState
-      icon={Search}
-      iconColor="text-gray-400"
-      iconBg="bg-gray-100"
-      title="검색 결과가 없습니다"
-      description="다른 키워드로 검색해보세요"
-      buttonValue="새로운 검색"
-      buttonType="outline"
-      buttonClassName="bg-gray-50 text-gray-700 transition-colors duration-300 ease-out hover:bg-gray-200"
-      onClick={onClick}
-      className={className}
-      {...props}
-    />
+    <BaseStateWrapper className={className} {...props}>
+      <BaseStateIcon
+        icon={Search}
+        iconColor="text-gray-400"
+        iconBg="bg-gray-100"
+      />
+      <BaseStateContent
+        title="검색 결과가 없습니다"
+        description="다른 키워드로 검색해보세요"
+      />
+      <BaseStateButton
+        buttonContent={'새로운 검색'}
+        buttonVariant="outline"
+        className="bg-gray-50 text-gray-700 transition-colors duration-300 ease-out hover:bg-gray-200"
+        onClick={onClick}
+      />
+    </BaseStateWrapper>
   )
 }
 

--- a/src/components/common/State/EmptyResultState.tsx
+++ b/src/components/common/State/EmptyResultState.tsx
@@ -1,0 +1,20 @@
+import { Search } from 'lucide-react'
+import BaseState from './BaseState'
+
+function EmptyResultState({ onClick }: { onClick?: () => void }) {
+  return (
+    <BaseState
+      icon={Search}
+      iconColor="text-gray-400"
+      iconBg="bg-gray-100"
+      title="검색 결과가 없습니다"
+      description="다른 키워드로 검색해보세요"
+      buttonValue="새로운 검색"
+      buttonType="outline"
+      buttonClassName="bg-gray-50 text-gray-700 transition-colors duration-300 ease-out hover:bg-gray-200"
+      onClick={onClick}
+    />
+  )
+}
+
+export default EmptyResultState

--- a/src/components/common/State/LoadingState.tsx
+++ b/src/components/common/State/LoadingState.tsx
@@ -1,0 +1,12 @@
+import BaseState from './BaseState'
+
+function LoadingState() {
+  return (
+    <BaseState
+      title="데이터를 불러오고 있습니다"
+      description="잠시만 기다려주세요..."
+    />
+  )
+}
+
+export default LoadingState

--- a/src/components/common/State/LoadingState.tsx
+++ b/src/components/common/State/LoadingState.tsx
@@ -1,12 +1,22 @@
-import BaseState from './BaseState'
+import type { ComponentProps } from 'react'
+import {
+  BaseStateContent,
+  BaseStateSpinner,
+  BaseStateWrapper,
+} from './BaseState'
 
-function LoadingState({ className }: React.HTMLAttributes<HTMLDivElement>) {
+function LoadingState({
+  className,
+  ...props
+}: ComponentProps<typeof BaseStateWrapper>) {
   return (
-    <BaseState
-      title="데이터를 불러오고 있습니다"
-      description="잠시만 기다려주세요..."
-      className={className}
-    />
+    <BaseStateWrapper className={className} {...props}>
+      <BaseStateSpinner />
+      <BaseStateContent
+        title="데이터를 불러오고 있습니다"
+        description="잠시만 기다려주세요..."
+      />
+    </BaseStateWrapper>
   )
 }
 

--- a/src/components/common/State/LoadingState.tsx
+++ b/src/components/common/State/LoadingState.tsx
@@ -1,10 +1,11 @@
 import BaseState from './BaseState'
 
-function LoadingState() {
+function LoadingState({ className }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <BaseState
       title="데이터를 불러오고 있습니다"
       description="잠시만 기다려주세요..."
+      className={className}
     />
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -111,6 +111,19 @@ body {
   );
 }
 
+@theme {
+  --animate-loading-state: loading-state 1.5s linear infinite;
+
+  @keyframes loading-state {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+}
+
 @layer utilities {
   .scrollbar-custom::-webkit-scrollbar {
     width: 16px;


### PR DESCRIPTION
## 🚀 PR 요약

조건부 렌더링 때 적용할 화면 상태 UI 3가지를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 화면 상태 UI의 베이스로 사용할 BaseState 추가
- 검색 결과 없음 상태 EmptyResultState 추가
- 데이터 없음 상태 EmptyDataState 추가
- 로딩 상태 LoadingState 추가

### 참고 사항

- Figma에서 검색 결과 없음 UI에 **필터 초기화 버튼**이 있으나, 저희가 작업하게 될 페이지에는 검색 필터링 기능이 들어간 페이지가 없기 때문에 제외하고 작업했습니다.
- EmptyResultState와 EmptyDataState에는 버튼이 한 개씩 있고 이 버튼에 onClick으로 이벤트 핸들러를 연결하여 사용하시면 됩니다.
  - EmptyResultState에는 **새로운 검색** 버튼이 있고, 아래 예시에서는 이 버튼을 클릭하면 입력 필드의 value가 초기화되도록 했습니다.
  - EmptyDataState에는 **+ 새로 만들기** 버튼이 있고, 아래 예시에서는 이 버튼을 클릭하면 `useNavigate`를 이용해 다른 페이지로 이동하도록 했습니다.
- 사용은 아래 예시처럼 해주시면 됩니다.
```
const [value, setValue] = useState('')
const navigate = useNavigate()

return (
  <div className="flex flex-col gap-5 p-20">
    <Input value={value} onChange={(e) => setValue(e.target.value)} />
    <div className="h-150">
      <EmptyResultState onClick={() => setValue('')} />
    </div>
    <div className="h-150">
      <EmptyDataState onClick={() => navigate('/')} />
    </div>
    <div className="h-150">
      <LoadingState />
    </div>
  </div>
)
```

### 스크린 샷

**화면 테스트 (gif)**
![StudyHub-Chrome2025-09-0422-05-26-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0bca67ed-c9f8-46bb-ac31-3eae7b1d9afd)

**모바일 사이즈 화면 (img)**
<img width="200" alt="localhost_5173_test(iPhone SE)" src="https://github.com/user-attachments/assets/a3516d51-138c-4f92-861d-df2c0673345b" />


## 🔗 연관된 이슈

> closes #80
