### PR TITLE
Feature: 마이페이지 내 정보 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router'
-import { LandingPage } from '@/pages'
-import { RootLayout, MyPageLayout, MyInfo, AuthLayout } from '@/components'
+import { LandingPage, MyInfo } from '@/pages'
+import { RootLayout, MyPageLayout, AuthLayout } from '@/components'
 
 function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router'
 import { LandingPage } from '@/pages'
-import { RootLayout, MyPageLayout, AuthLayout } from '@/components'
+import { RootLayout, MyPageLayout, MyInfo, AuthLayout } from '@/components'
 
 function App() {
   return (
@@ -17,7 +17,7 @@ function App() {
         </Route>
 
         <Route path="my-page" element={<MyPageLayout />}>
-          <Route index element={<div>my-page</div>} />
+          <Route index element={<MyInfo />} />
           <Route
             path="bookmarked-recruitment"
             element={<div>bookmarked-recruitment</div>}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -18,7 +18,7 @@ import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
 import Avatar from '@/components/avatar/Avatar'
 import AuthLayout from '@/components/layout/AuthLayout'
 import Notification from '@/components/notification/Notification'
-import { MyInfo } from '@/components/mypage/MyInfo'
+import { UserInfoDescription } from '@/components/mypage/InfoDescription'
 
 export {
   Badge,
@@ -40,5 +40,5 @@ export {
   Avatar,
   AuthLayout,
   Notification,
-  MyInfo,
+  UserInfoDescription,
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -18,6 +18,7 @@ import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
 import Avatar from '@/components/avatar/Avatar'
 import AuthLayout from '@/components/layout/AuthLayout'
 import Notification from '@/components/notification/Notification'
+import { MyInfo } from '@/components/mypage/MyInfo'
 
 export {
   Badge,
@@ -39,4 +40,5 @@ export {
   Avatar,
   AuthLayout,
   Notification,
+  MyInfo,
 }

--- a/src/components/layout/MyPageLayout.tsx
+++ b/src/components/layout/MyPageLayout.tsx
@@ -3,9 +3,9 @@ import { MyPageSideBar } from '@/components'
 
 export default function MyPageLayout() {
   return (
-    <div className="flex items-start justify-start gap-8 bg-gray-100 p-8">
+    <div className="flex items-start justify-center gap-8 bg-gray-100 p-8">
       <MyPageSideBar />
-      <div className="min-h-[700px] flex-1 rounded-lg border border-gray-200 bg-white p-6">
+      <div className="min-h-[700px] max-w-4xl flex-1 rounded-lg border border-gray-200 bg-white p-8">
         <Outlet />
       </div>
     </div>

--- a/src/components/mypage/InfoDescription.tsx
+++ b/src/components/mypage/InfoDescription.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface InfoDescriptionProps {
+  title: string
+  detail: string
+}
+
+interface InfoDescriptionList {
+  infoList: InfoDescriptionProps[]
+}
+
+export function InfoDescription({ infoList }: InfoDescriptionList): ReactNode {
+  return (
+    <dl className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      {infoList.map((List, index) => (
+        <div key={index}>
+          <dt className="pb-2 text-sm text-gray-700">{List.title}</dt>
+          <dd className="flex h-12 items-center bg-gray-50 p-4 text-gray-900">
+            {List.detail}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/mypage/InfoDescription.tsx
+++ b/src/components/mypage/InfoDescription.tsx
@@ -1,22 +1,24 @@
 import type { ReactNode } from 'react'
 
-interface InfoDescriptionProps {
+interface InfoDescription {
   title: string
   detail: string
 }
 
-interface InfoDescriptionList {
-  infoList: InfoDescriptionProps[]
+interface InfoDescriptionProps {
+  infoList: InfoDescription[]
 }
 
-export function InfoDescription({ infoList }: InfoDescriptionList): ReactNode {
+export function UserInfoDescription({
+  infoList,
+}: InfoDescriptionProps): ReactNode {
   return (
     <dl className="grid grid-cols-1 gap-6 md:grid-cols-2">
-      {infoList.map((List, index) => (
+      {infoList.map((list, index) => (
         <div key={index}>
-          <dt className="pb-2 text-sm text-gray-700">{List.title}</dt>
+          <dt className="pb-2 text-sm text-gray-700">{list.title}</dt>
           <dd className="flex h-12 items-center bg-gray-50 p-4 text-gray-900">
-            {List.detail}
+            {list.detail}
           </dd>
         </div>
       ))}

--- a/src/components/mypage/MyInfo.tsx
+++ b/src/components/mypage/MyInfo.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from 'react'
+import { Button } from '@/components'
+import { InfoDescription } from './InfoDescription'
+
+export function MyInfo(): ReactNode {
+  return (
+    <main>
+      <section className="flex flex-col gap-8 pb-16" aria-labelledby="myInfo">
+        <header className="flex justify-between">
+          <div className="flex flex-col">
+            <h2 className="text-heading3 pb-2">내 정보</h2>
+            <p className="text-secondary">
+              회원 정보를 확인하고 수정할 수 있습니다
+            </p>
+          </div>
+          <Button size="lg" className="my-auto py-2.5">
+            수정하기
+          </Button>
+        </header>
+        <figure className="flex flex-col items-center gap-4">
+          <div className="size-32 overflow-hidden rounded-full">
+            <img
+              src=""
+              alt="사용자 프로필 이미지"
+              className="h-full w-full object-cover object-center"
+            />
+          </div>
+          <figcaption className="text-heading5">프로필 이미지</figcaption>
+        </figure>
+        <InfoDescription
+          infoList={[
+            { title: '이메일', detail: 'kim.dev@example.com' },
+            { title: '휴대폰 번호', detail: '' },
+            { title: '닉네임', detail: '' },
+            { title: '생년월일', detail: '' },
+            { title: '이름', detail: '' },
+          ]}
+        />
+      </section>
+
+      <section
+        className="border-y-[1px] border-gray-200 py-16 pt-8"
+        aria-labelledby="passwordChange"
+      >
+        <header className="flex justify-between">
+          <div className="flex flex-col">
+            <h2 className="text-heading3 pb-2">비밀번호</h2>
+            <p className="text-secondary">
+              보안을 위해 정기적으로 비밀번호를 변경해주세요
+            </p>
+          </div>
+          <Button
+            size="lg"
+            className="my-auto bg-gray-500 py-2.5 hover:bg-gray-400 active:bg-gray-600"
+          >
+            비밀번호 변경
+          </Button>
+        </header>
+      </section>
+      <section className="py-16 pt-8" aria-labelledby="unregister">
+        <header className="flex justify-between">
+          <div className="flex flex-col">
+            <h2 className="text-heading3 pb-2">회원 탈퇴</h2>
+            <div className="flex items-end gap-2">
+              <span className="text-secondary">
+                계정을 삭제하고 서비스를 떠나실 수 있습니다
+              </span>
+              <span className="text-primary-600 text-sm">
+                탈퇴 후 2주간 계정 복구가 가능합니다
+              </span>
+            </div>
+          </div>
+          <Button variant="danger" size="lg" className="my-auto py-2.5">
+            회원 탈퇴
+          </Button>
+        </header>
+      </section>
+    </main>
+  )
+}

--- a/src/pages/MyInfo.tsx
+++ b/src/pages/MyInfo.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
-import { Button } from '@/components'
-import { InfoDescription } from './InfoDescription'
+import { Button, UserInfoDescription } from '@/components'
 
 export function MyInfo(): ReactNode {
   return (
@@ -27,7 +26,7 @@ export function MyInfo(): ReactNode {
           </div>
           <figcaption className="text-heading5">프로필 이미지</figcaption>
         </figure>
-        <InfoDescription
+        <UserInfoDescription
           infoList={[
             { title: '이메일', detail: 'kim.dev@example.com' },
             { title: '휴대폰 번호', detail: '' },
@@ -39,7 +38,7 @@ export function MyInfo(): ReactNode {
       </section>
 
       <section
-        className="border-y-[1px] border-gray-200 py-16 pt-8"
+        className="border-y border-gray-200 py-16 pt-8"
         aria-labelledby="passwordChange"
       >
         <header className="flex justify-between">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
-import LandingPage from './LandingPage'
+import LandingPage from '@/pages/LandingPage'
+import { MyInfo } from '@/pages/MyInfo'
 
-export { LandingPage }
+export { LandingPage, MyInfo }


### PR DESCRIPTION
## 🚀 PR 요약

> 마이페이지 내 정보 탭 UI 생성 

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

### 작업 사항

- 마이페이지 내정보 탭의 UI를 section태그 3개로 나누어 생성했습니다.

### 참고 사항

- 시멘틱 태그 잘 모르지만 최대한 활용하려 해봤습니다.

### 스크린 샷

<img width="2332" height="1880" alt="내정보 탭" src="https://github.com/user-attachments/assets/9d28b326-f4c8-4e3c-8a07-ea03cbad2a1e" />


## 🔗 연관된 이슈

> closes #88 
