### PR TITLE
Fix: 랜딩 페이지 Route 경로 수정

### DIFF
--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -6,7 +6,8 @@ function MainRoutes() {
   return (
     <Routes>
       <Route element={<RootLayout />}>
-        <Route index element={<LandingPage />} />
+        {/* TODO: /landing -> index로 수정 */}
+        <Route path="landing" element={<LandingPage />} />
 
         <Route path="auth" element={<AuthLayout />}>
           <Route path="login" element={<div>login</div>} />

--- a/src/routes/TestRoutes.tsx
+++ b/src/routes/TestRoutes.tsx
@@ -9,7 +9,7 @@ function Root() {
   return (
     <div className="flex h-screen items-center justify-center gap-10">
       <Button className="px-10 py-6 text-2xl">
-        <Link to="/main">사이트 메인</Link>
+        <Link to="/landing">사이트 메인</Link>
       </Button>
       <Button className="px-10 py-6 text-2xl">
         <Link to="/test-hub">테스트 허브</Link>
@@ -22,7 +22,7 @@ function TestRoutes() {
   return (
     <Routes>
       <Route path="/" element={<Root />} />
-      <Route path="/main/*" element={<MainRoutes />} />
+      <Route path="/*" element={<MainRoutes />} />
       <Route path="/test-hub/*" element={<TestHub />}>
         {testPages.map((p) => {
           const Page = lazy(p.loader)


### PR DESCRIPTION
TestRoutes가 우선 적용된 현재, MainRoutes 연결에도 문제가 없도록 수정

## 🚀 PR 요약

MainRoutes의 LandingPage 경로를 개발 상 문제가 없도록 임시 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 참고 사항

- TestRoutes가 우선 적용된 현재, 원활한 개발을 위해 MainRoutes 연결에도 문제가 없도록 수정했습니다.
- 이후 MainRoutes로 라우트 적용을 변경할 때 TODO 주석을 참고하여 라우트 경로 수정이 필요합니다.

### 스크린 샷

![화면 캡처 2025-09-08 140558](https://github.com/user-attachments/assets/53aeecaf-3204-44e2-98f7-4889c3fc3e69)

## 🔗 연관된 이슈

> closes #111 