### PR TITLE
Feature: Auth 폼 유효성 검사 기능 및 테스트 페이지 추가

### DIFF
--- a/src/schemas/form-schema/auth-schema.ts
+++ b/src/schemas/form-schema/auth-schema.ts
@@ -4,20 +4,28 @@ export const authSchema = z
   .object({
     email: z
       .email('유효한 이메일 주소를 입력해주세요')
+      .trim()
       .min(1, '이메일은 필수로 입력해야 합니다'),
     password: z
       .string()
+      .regex(/^\S+$/, '공백은 사용할 수 없습니다')
       .min(8, '비밀번호는 최소 8자 이상이어야 합니다')
-      .max(15, '비밀번호는 최대 15자까지 가능합니다'),
+      .max(15, '비밀번호는 최대 15자까지 가능합니다')
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/,
+        '비밀번호는 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다'
+      ),
     confirmPassword: z
       .string()
       .min(1, '비밀번호 확인은 필수로 입력해야 합니다'),
     name: z
       .string()
+      .trim()
       .min(1, '이름은 필수로 입력해야 합니다')
       .max(30, '이름은 최대 30자까지 가능합니다'),
     nickname: z
       .string()
+      .trim()
       .min(2, '닉네임은 최소 2자 이상이어야 합니다')
       .max(10, '닉네임은 최대 10자까지 가능합니다'),
     birthday: z

--- a/src/schemas/form-schema/auth-schema.ts
+++ b/src/schemas/form-schema/auth-schema.ts
@@ -15,11 +15,11 @@ export const authSchema = z
     name: z
       .string()
       .min(1, '이름은 필수로 입력해야 합니다')
-      .max(20, '이름은 최대 20자까지 가능합니다'),
+      .max(30, '이름은 최대 30자까지 가능합니다'),
     nickname: z
       .string()
       .min(2, '닉네임은 최소 2자 이상이어야 합니다')
-      .max(8, '닉네임은 최대 8자까지 가능합니다'),
+      .max(10, '닉네임은 최대 10자까지 가능합니다'),
     birthday: z
       .string()
       .min(1, '생년월일은 필수로 입력해야 합니다')

--- a/src/schemas/form-schema/auth-schema.ts
+++ b/src/schemas/form-schema/auth-schema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+export const authSchema = z
+  .object({
+    email: z
+      .email('유효한 이메일 주소를 입력해주세요')
+      .min(1, '이메일은 필수로 입력해야 합니다'),
+    password: z
+      .string()
+      .min(8, '비밀번호는 최소 8자 이상이어야 합니다')
+      .max(15, '비밀번호는 최대 15자까지 가능합니다'),
+    confirmPassword: z
+      .string()
+      .min(1, '비밀번호 확인은 필수로 입력해야 합니다'),
+    name: z
+      .string()
+      .min(1, '이름은 필수로 입력해야 합니다')
+      .max(20, '이름은 최대 20자까지 가능합니다'),
+    nickname: z
+      .string()
+      .min(2, '닉네임은 최소 2자 이상이어야 합니다')
+      .max(8, '닉네임은 최대 8자까지 가능합니다'),
+    birthday: z
+      .string()
+      .min(1, '생년월일은 필수로 입력해야 합니다')
+      .length(8, '생년월일은 8자리(YYYYMMDD)로 입력해주세요')
+      .regex(/^\d{8}$/, '생년월일은 숫자만 입력해주세요'),
+    phoneNumber: z
+      .string()
+      .min(1, '휴대전화 번호는 필수로 입력해야 합니다')
+      .length(11, '휴대전화 번호는 11자리(ex. 01012345678)로 입력해주세요')
+      .regex(
+        /^010\d{8}$/,
+        '휴대전화 번호는 하이픈(-) 없이 010으로 시작하는 11자리여야 합니다'
+      ),
+    verificationCode: z
+      .string()
+      .min(1, '인증코드는 필수로 입력해야 합니다')
+      .length(6, '인증코드는 6자리(숫자 + 영문)로 입력해주세요'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호와 일치하지 않습니다',
+    path: ['confirmPassword'],
+  })
+
+export type AuthSchemaType = z.infer<typeof authSchema>

--- a/src/tests/AuthFormVerificationTest.tsx
+++ b/src/tests/AuthFormVerificationTest.tsx
@@ -1,0 +1,124 @@
+import { AuthSubmitButton } from '@/components/auth'
+import { Input, InputErrorMessage, InputLabel } from '@/components/common/input'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  authSchema,
+  type AuthSchemaType,
+} from '@/schemas/form-schema/auth-schema'
+import { useToast } from '@/hooks'
+
+function AuthFormVerificationTest() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<AuthSchemaType>({
+    resolver: zodResolver(authSchema),
+  })
+  const { triggerToast } = useToast()
+
+  const onSubmit = async (data: AuthSchemaType) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    triggerToast('success', 'Auth 유효성 검사 성공!')
+    console.log('입력 내용: ', data)
+    reset()
+  }
+
+  return (
+    <section
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full flex-col gap-10"
+    >
+      <h3 className="text-center text-xl font-semibold">유효성 검사 Test</h3>
+
+      <form className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>이메일</InputLabel>
+          <Input
+            {...register('email')}
+            type="email"
+            placeholder="이메일을 입력해주세요"
+          />
+          {errors.email && (
+            <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>비밀번호</InputLabel>
+          <Input
+            {...register('password')}
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+          />
+          {errors.password && (
+            <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>비밀번호 확인</InputLabel>
+          <Input
+            {...register('confirmPassword')}
+            type="password"
+            placeholder="비밀번호를 한번 더 입력해주세요"
+          />
+          {errors.confirmPassword && (
+            <InputErrorMessage>{`${errors.confirmPassword.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>이름</InputLabel>
+          <Input {...register('name')} placeholder="이름을 입력해주세요" />
+          {errors.name && (
+            <InputErrorMessage>{`${errors.name.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>닉네임</InputLabel>
+          <Input
+            {...register('nickname')}
+            placeholder="닉네임을 입력해주세요"
+          />
+          {errors.nickname && (
+            <InputErrorMessage>{`${errors.nickname.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>생년월일</InputLabel>
+          <Input
+            {...register('birthday')}
+            placeholder="생년월일 8자리를 입력해주세요 (ex. 20001010)"
+          />
+          {errors.birthday && (
+            <InputErrorMessage>{`${errors.birthday.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>휴대전화</InputLabel>
+          <Input
+            {...register('phoneNumber')}
+            type="tel"
+            placeholder="01012345678"
+          />
+          {errors.phoneNumber && (
+            <InputErrorMessage>{`${errors.phoneNumber.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <InputLabel isRequired>인증번호</InputLabel>
+          <Input
+            {...register('verificationCode')}
+            placeholder="인증번호 6자리를 입력해주세요"
+          />
+          {errors.verificationCode && (
+            <InputErrorMessage>{`${errors.verificationCode.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <AuthSubmitButton disabled={isSubmitting}>Submit</AuthSubmitButton>
+      </form>
+    </section>
+  )
+}
+
+export default AuthFormVerificationTest

--- a/src/tests/AuthFormVerificationTest.tsx
+++ b/src/tests/AuthFormVerificationTest.tsx
@@ -27,13 +27,10 @@ function AuthFormVerificationTest() {
   }
 
   return (
-    <section
-      onSubmit={handleSubmit(onSubmit)}
-      className="flex w-full flex-col gap-10"
-    >
+    <section className="flex w-full flex-col gap-10">
       <h3 className="text-center text-xl font-semibold">유효성 검사 Test</h3>
 
-      <form className="flex flex-col gap-6">
+      <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col gap-2">
           <InputLabel isRequired>이메일</InputLabel>
           <Input


### PR DESCRIPTION
## 🚀 PR 요약

react-hook-form과 zod를 사용해 Auth 관련 페이지에 사용되는 모든 폼의 유효성 검사 기능을 추가하고, 이를 테스트할 수 있는 테스트 페이지를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] test: 테스트 코드 추가/수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- schemas/form-schema 폴더에 auth-schema 추가
- AuthFormVerificationTest에 폼 유효성 검사 테스트 작성
  - 이메일: 이메일 형식 문자열
  - 비밀번호: 영문 대소문자, 숫자, 특수문자를 포함한 8~15자 문자열
  - 비밀번호 확인: 비밀번호와 일치
  - 이름: 최대 30자 문자열
  - 닉네임: 최대 10자 문자열
  - 생년월일: `19900101`와 같은 8자리 문자열
  - 휴대전화 번호: `01012345678`와 같은 11자리 문자열
  - 인증코드: 숫자와 영문이 섞인 6자리 문자열

### 참고 사항

- 백엔드 팀의 답변을 참고하여 기준 추가했습니다.
- 생년월일의 경우, 입력할 때는 `19900101`와 같은 형식이지만, 서버로 보낼 때는 `1990-01-01` 형식이어야 합니다.

### 스크린 샷


https://github.com/user-attachments/assets/f8857e89-e256-4e23-9b7c-be51904c2ee6



## 🔗 연관된 이슈

> closes #121
