### PR TITLE
Bug: 공용 드롭다운 컴포넌트 에러 해결 및 수정

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,8 +1,8 @@
 import { ChevronDown, type LucideIcon } from 'lucide-react'
-import Input from './Input'
 import { useState, type ComponentProps } from 'react'
 import { cn } from '@/utils'
 import { cva, type VariantProps } from 'class-variance-authority'
+import { Input } from '@/components/common/input'
 
 const dropdownItemVariants = cva(
   'text-left w-full relative cursor-pointer px-4 py-3 text-base hover:bg-gray-100',

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -16,6 +16,7 @@ import AvatarSkeleton from '@/components/common/Skeleton/AvatarSkeleton'
 import Avatar from '@/components/common/Avatar'
 import AuthLayout from '@/components/layout/AuthLayout'
 import Notification from '@/components/notification/Notification'
+import Dropdown from '@/components/common/Dropdown'
 
 export {
   Badge,
@@ -35,4 +36,5 @@ export {
   Avatar,
   AuthLayout,
   Notification,
+  Dropdown,
 }


### PR DESCRIPTION
## 🚀 PR 요약

공용 드롭다운 컴포넌트의 **Input** 컴포넌트 `import` 경로 에러를 해결하고 **components/index.tsx**에 추가했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **Input** 컴포넌트 `import` 경로 에러 해결
- **components/index.tsx**에 추가

### 참고 사항

- vercel 배포 에러 해결을 위해 수정했습니다.

## 🔗 연관된 이슈

> closes #135 
