### PR TITLE
Feature: 채팅 컴포넌트 외부 제어 옵션 추가

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -1,12 +1,23 @@
-import { Modal, ModalTrigger, useModalContext } from '@/components/common/Modal'
+import { Modal, ModalTrigger } from '@/components/common/Modal'
 import { Button } from '@/components'
 import { MessageCircle, X } from 'lucide-react'
 
 import ChatRoomContent from './ChatRoomContent'
-
+import { useChatRoomStore } from '@/store'
 export default function Chat() {
+  const { isOpen, closeChatRoom, openChatRoom, toggleChatRoom } =
+    useChatRoomStore()
+
   return (
-    <Modal isOverlay={false}>
+    <Modal
+      isOverlay={false}
+      externalModalControl={{
+        isOpen,
+        open: openChatRoom,
+        close: closeChatRoom,
+        toggle: toggleChatRoom,
+      }}
+    >
       <ModalTrigger className="fixed right-5 bottom-5">
         <ChatTriggerButton />
       </ModalTrigger>
@@ -16,7 +27,8 @@ export default function Chat() {
 }
 
 function ChatTriggerButton() {
-  const { isOpen } = useModalContext()
+  const { isOpen } = useChatRoomStore()
+
   return (
     <Button className="size-16 cursor-pointer rounded-full">
       {isOpen ? <X className="w-full" /> : <MessageCircle className="w-full" />}

--- a/src/components/chat/ChatRoomContent.tsx
+++ b/src/components/chat/ChatRoomContent.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from '@/utils'
 import { ArrowLeft } from 'lucide-react'
 import ChatRoom from './ChatRoom'
+import { useChatRoomStore } from '@/store'
 
 const dummyChatroomsData: ComponentProps<typeof ChatRoomCard>[] = [
   {
@@ -51,7 +52,7 @@ const dummyChatroomsData: ComponentProps<typeof ChatRoomCard>[] = [
 ]
 
 export default function ChatRoomContent() {
-  const [chatRoomId, setChatRoomId] = useState('')
+  const { chatRoomId, setChatRoomId } = useChatRoomStore()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/src/components/chat/ChatRoomContent.tsx
+++ b/src/components/chat/ChatRoomContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ComponentProps } from 'react'
+import { useEffect, useRef, type ComponentProps } from 'react'
 import ChatRoomCard from './ChatRoomCard'
 import {
   ModalContent,

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -277,17 +277,38 @@ function ModalOverlay() {
 interface ModalProps {
   children: ReactNode
   isOverlay?: boolean
+
+  externalModalControl?: ModalContextValue
 }
 
-function Modal({ children, isOverlay = true }: ModalProps) {
+function Modal({
+  children,
+  externalModalControl,
+  isOverlay = true,
+}: ModalProps) {
   const [isOpen, setIsOpen] = useState(false)
 
-  const open = () => setIsOpen(true)
-  const close = () => setIsOpen(false)
-  const toggle = () => setIsOpen((prev) => !prev)
+  const open = externalModalControl
+    ? externalModalControl.open
+    : () => setIsOpen(true)
+
+  const close = externalModalControl
+    ? externalModalControl.close
+    : () => setIsOpen(false)
+
+  const toggle = externalModalControl
+    ? externalModalControl.toggle
+    : () => setIsOpen((prev) => !prev)
 
   return (
-    <ModalContext.Provider value={{ isOpen, open, close, toggle }}>
+    <ModalContext.Provider
+      value={{
+        isOpen: externalModalControl ? externalModalControl.isOpen : isOpen,
+        open,
+        close,
+        toggle,
+      }}
+    >
       {isOverlay ? <ModalOverlay /> : null}
       <div>{children}</div>
     </ModalContext.Provider>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 // store
 import { useToastStore } from '@/store/useToastStore'
 import { useNotificationNavigationItemStore } from '@/store/useNotificationNavigationItemStore'
+import { useChatRoomStore } from '@/store/useChatRoomStore'
 
-export { useToastStore, useNotificationNavigationItemStore }
+export { useToastStore, useNotificationNavigationItemStore, useChatRoomStore }

--- a/src/store/useChatRoomStore.tsx
+++ b/src/store/useChatRoomStore.tsx
@@ -1,0 +1,18 @@
+import { create } from 'zustand'
+
+interface ChatRoomStore {
+  chatRoomId: string
+  setChatRoomId: (newChatRoomId: string) => void
+  openChatRoom: (() => void) | null
+  setOpenChatRoom: (openFunction: () => void) => void
+}
+
+export const useChatRoomStore = create<ChatRoomStore>((set) => ({
+  chatRoomId: '',
+  openChatRoom: null,
+
+  setChatRoomId: (newChatRoomId) => set(() => ({ chatRoomId: newChatRoomId })),
+
+  setOpenChatRoom: (openFunction) =>
+    set(() => ({ openChatRoom: openFunction })),
+}))

--- a/src/store/useChatRoomStore.tsx
+++ b/src/store/useChatRoomStore.tsx
@@ -2,17 +2,20 @@ import { create } from 'zustand'
 
 interface ChatRoomStore {
   chatRoomId: string
+  isOpen: boolean
+
   setChatRoomId: (newChatRoomId: string) => void
-  openChatRoom: (() => void) | null
-  setOpenChatRoom: (openFunction: () => void) => void
+  openChatRoom: () => void
+  closeChatRoom: () => void
+  toggleChatRoom: () => void
 }
 
 export const useChatRoomStore = create<ChatRoomStore>((set) => ({
   chatRoomId: '',
-  openChatRoom: null,
+  isOpen: false,
 
+  openChatRoom: () => set(() => ({ isOpen: true })),
+  closeChatRoom: () => set(() => ({ isOpen: false })),
+  toggleChatRoom: () => set((state) => ({ isOpen: !state.isOpen })),
   setChatRoomId: (newChatRoomId) => set(() => ({ chatRoomId: newChatRoomId })),
-
-  setOpenChatRoom: (openFunction) =>
-    set(() => ({ openChatRoom: openFunction })),
 }))

--- a/src/tests/ChatGlobalStateTest.tsx
+++ b/src/tests/ChatGlobalStateTest.tsx
@@ -9,10 +9,8 @@ export default function ChatGlobalStateTest() {
   const handleButtonClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault()
 
-    if (openChatRoom) {
-      setChatRoomId(CHAT_ROOM_ID)
-      openChatRoom()
-    }
+    setChatRoomId(CHAT_ROOM_ID)
+    openChatRoom()
   }
 
   return (

--- a/src/tests/ChatGlobalStateTest.tsx
+++ b/src/tests/ChatGlobalStateTest.tsx
@@ -1,0 +1,28 @@
+import { Button, Chat } from '@/components'
+import { useChatRoomStore } from '@/store'
+
+const CHAT_ROOM_ID = 'chat-1111'
+
+export default function ChatGlobalStateTest() {
+  const { setChatRoomId, openChatRoom } = useChatRoomStore((state) => state)
+
+  const handleButtonClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault()
+
+    if (openChatRoom) {
+      setChatRoomId(CHAT_ROOM_ID)
+      openChatRoom()
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <h1 className="text-heading3">
+        아래 버튼을 클릭하면 채팅방이 열려야합니다.
+      </h1>
+      <Button onClick={handleButtonClick}>채팅 열기</Button>
+
+      <Chat />
+    </div>
+  )
+}


### PR DESCRIPTION
## 🚀 PR 요약

> 채팅 컴포넌트 외부 제어 옵션 추가

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- useChatRoomStore zustand 훅 추가
- 모달을 외부에서도 제어할 수 있게 리팩토링
- ChatRoom 정보를 전역상태로 제어

### 참고 사항

- 채팅방 자동으로 스크롤 안 내려가는 문제 해결

### 스크린 샷

https://github.com/user-attachments/assets/1e3ff46c-2fac-4be4-872e-0ccc2e876685

## 트러블 슈팅
### 첫 번째 시도
+ 첫 번째 시도로 전역상태를 일단 만들고 모달 내부 컨텍스트를 등록 하는 방식을 생각했습니다.
+ 이렇게 하면 기존의 모달 컴포넌트를 건들지 않고 목표를 달성할 수 있을 줄 알았습니다.
<img width="527" height="425" alt="Screenshot 2025-09-10 at 2 35 13 PM" src="https://github.com/user-attachments/assets/50718c38-4a63-46b8-9fe9-0f7a1fbdbe17" />

+ 하지만 이렇게 하니 useModalContext가 <ModalContext.Provider> 밖에서 호출되는 문제가 발생했습니다.
```typescript
function ChatTriggerButton() {
  const { isOpen, open } = useModalContext() // <- 여기서 문제 발생
  const { setOpen } = useChatRoomStore() // <- 여기서 문제 발생

  setOpen(open)
  //other codes
```
+ 사실 제 생각으론 원래 아무런 문제가 없었어야 했습니다. 어차피 useModalContext와 useChatRoomStore가 호출되는 것은 \<Modal\> 안에 있는 컴포넌트이기 때문입니다. 아마 zustand 자체 구현 방식 문제이거나 전역 상태에 대한 저의 공부가 부족해서 그런 것 같습니다.


### 두 번째 시도 (성공)
+ 그래서 두 번재 시도로는 외부 컨트롤러를 prop으로 받는 옵션을 만들었습니다.
+ 외부에서 별도의 컨트롤러를 Modal이 prop으로 받으면 외부 컨트롤러를 아니면 내부 컨트롤러를 사용하도록 코드를 바꿨습니다.
```typescript
function Modal({
  children,
  externalModalControl,
  isOverlay = true,
}: ModalProps) {
  const [isOpen, setIsOpen] = useState(false)

  const open = externalModalControl
    ? externalModalControl.open
    : () => setIsOpen(true)

  const close = externalModalControl
    ? externalModalControl.close
    : () => setIsOpen(false)

  const toggle = externalModalControl
    ? externalModalControl.toggle
    : () => setIsOpen((prev) => !prev)

  return (
    <ModalContext.Provider
      value={{
        isOpen: externalModalControl ? externalModalControl.isOpen : isOpen,
        open,
        close,
        toggle,
      }}
    >
      {isOverlay ? <ModalOverlay /> : null}
      <div>{children}</div>
    </ModalContext.Provider>
  )
}
```
+ 이렇게 구성하니 첫 번재 방식에서 컨트롤러 등록 및 제어가 양뱡향이었던 것에 비해 단방향으로 바뀌어서 코드 이해도 직관적으로 바뀌었습니다.
 
<img width="700" height="379" alt="Screenshot 2025-09-10 at 2 50 19 PM" src="https://github.com/user-attachments/assets/9f76dde9-cbed-43dc-bae8-5d13272032be" />


## 🔗 연관된 이슈

> closes #136 <- 이번에 작업한 이슈 번호
