### PR TITLE
Feature: 회원가입 페이지 UI 추가

### DIFF
--- a/src/components/header/NavList.tsx
+++ b/src/components/header/NavList.tsx
@@ -14,7 +14,11 @@ export function HeaderNavList(): ReactNode {
       <NavComponent label="구인 공고" />
       {/* 이 줄 이후의 요소들만 로그인 시 변경 예정 */}
       <NavComponent label="로그인" event={() => navigate('/auth/login')} />
-      <Button size="sm" className="ml-4 w-full">
+      <Button
+        size="sm"
+        className="ml-4 w-full"
+        onClick={() => navigate('/auth/signup')}
+      >
         회원가입
       </Button>
     </div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,0 +1,91 @@
+import {
+  AuthBadge,
+  AuthContainer,
+  AuthDescription,
+  AuthLink,
+  AuthLogo,
+  AuthSubmitButton,
+  AuthTitle,
+  AuthVerifyButton,
+} from '@/components/auth'
+import { Input, InputDescription, InputLabel } from '@/components/common/input'
+
+const flexRowStyle = 'flex gap-3'
+const flexColStyle = 'flex flex-col gap-3'
+
+function Signup() {
+  return (
+    <AuthContainer className="flex flex-col gap-10">
+      <div className={flexColStyle}>
+        <AuthLogo />
+        <AuthTitle>회원가입</AuthTitle>
+        <div className="flex justify-center gap-1">
+          <AuthDescription>이미 계정이 있으신가요?</AuthDescription>
+          <AuthLink to="/auth/login">로그인하기</AuthLink>
+        </div>
+      </div>
+      <form className="flex flex-col gap-10">
+        <div className={flexColStyle}>
+          <InputLabel isRequired>이름</InputLabel>
+          <Input placeholder="이름을 입력해주세요" />
+        </div>
+        <div className={flexColStyle}>
+          <InputLabel isRequired>닉네임</InputLabel>
+          <div className={flexRowStyle}>
+            <Input placeholder="닉네임을 입력해주세요" />
+            <AuthVerifyButton>중복확인</AuthVerifyButton>
+          </div>
+        </div>
+        <div className={flexColStyle}>
+          <InputLabel isRequired>생년월일</InputLabel>
+          <Input placeholder="생년월일을 입력해주세요 (ex. 20001004)" />
+        </div>
+        <div className={flexColStyle}>
+          <InputLabel isRequired>성별</InputLabel>
+          <div className="flex gap-3">
+            <AuthBadge isSelected>남</AuthBadge>
+            <AuthBadge>여</AuthBadge>
+          </div>
+        </div>
+        <div className={flexColStyle}>
+          <div className="flex gap-3">
+            <InputLabel isRequired>이메일</InputLabel>
+            <InputDescription>로그인 시 아이디로 사용합니다.</InputDescription>
+          </div>
+          <div className={flexRowStyle}>
+            <Input placeholder="이메일을 입력해주세요" />
+            <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+          </div>
+          <div className={flexRowStyle}>
+            <Input placeholder="인증코드 6자리를 입력해주세요" />
+            <AuthVerifyButton disabled>인증코드확인</AuthVerifyButton>
+          </div>
+        </div>
+        <div className={flexColStyle}>
+          <InputLabel isRequired>휴대전화</InputLabel>
+          <div className="flex gap-3">
+            <Input placeholder="휴대전화 번호를 입력해주세요 (ex. 01012345678)" />
+            <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+          </div>
+          <div className={flexRowStyle}>
+            <Input placeholder="인증코드 6자리를 입력해주세요" />
+            <AuthVerifyButton disabled>인증코드확인</AuthVerifyButton>
+          </div>
+        </div>
+        <div className={flexColStyle}>
+          <div className={flexRowStyle}>
+            <InputLabel isRequired>비밀번호</InputLabel>
+            <InputDescription>
+              8~15자의 영문 대소문자, 숫자, 특수문자 포함
+            </InputDescription>
+          </div>
+          <Input placeholder="비밀번호를 입력해주세요" />
+          <Input placeholder="비밀번호를 다시 입력해주세요" />
+        </div>
+        <AuthSubmitButton>가입하기</AuthSubmitButton>
+      </form>
+    </AuthContainer>
+  )
+}
+
+export default Signup

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -42,9 +42,25 @@ function Signup() {
         </div>
         <div className={flexColStyle}>
           <InputLabel isRequired>성별</InputLabel>
-          <div className="flex gap-3">
-            <AuthBadge isSelected>남</AuthBadge>
-            <AuthBadge>여</AuthBadge>
+          <div className={flexRowStyle}>
+            <label htmlFor="gender-male">
+              <AuthBadge isSelected>남</AuthBadge>
+            </label>
+            <input
+              id="gender-male"
+              type="radio"
+              value="male"
+              className="hidden"
+            />
+            <label htmlFor="gender-female">
+              <AuthBadge>여</AuthBadge>
+            </label>
+            <input
+              id="gender-female"
+              type="radio"
+              value="female"
+              className="hidden"
+            />
           </div>
         </div>
         <div className={flexColStyle}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,5 +2,6 @@ import LandingPage from '@/pages/LandingPage'
 import { MyInfo } from '@/pages/my-page/MyInfo'
 import BookmarkedRecruitment from '@/pages/my-page/BookmarkedRecruitment'
 import Login from '@/pages/Login'
+import Signup from '@/pages/Signup'
 
-export { LandingPage, MyInfo, BookmarkedRecruitment, Login }
+export { LandingPage, MyInfo, BookmarkedRecruitment, Login, Signup }

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -1,5 +1,11 @@
 import { AuthLayout, MyPageLayout, RootLayout } from '@/components'
-import { BookmarkedRecruitment, LandingPage, Login, MyInfo } from '@/pages'
+import {
+  BookmarkedRecruitment,
+  LandingPage,
+  Login,
+  MyInfo,
+  Signup,
+} from '@/pages'
 import { Route, Routes } from 'react-router'
 
 function MainRoutes() {
@@ -11,7 +17,7 @@ function MainRoutes() {
 
         <Route path="auth" element={<AuthLayout />}>
           <Route path="login" element={<Login />} />
-          <Route path="signup" element={<div>signup</div>} />
+          <Route path="signup" element={<Signup />} />
           <Route path="find-email" element={<div>find-email</div>} />
           <Route path="find-password" element={<div>find-password</div>} />
           <Route path="restore-user" element={<div>restore-user</div>} />


### PR DESCRIPTION
## 🚀 PR 요약

회원가입 페이지의 UI를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 회원가입 페이지 UI 추가
- /auth/signup으로 이동 시 Signup 컴포넌트 렌더링되도록 수정

### 참고 사항

- Figma 디자인을 기반으로 페이지의 UI 구성만 추가했습니다.
- **NavList.tsx**의 경우, 이전에 클릭했을 시 페이지 이동 되는 요소는 **Link** 컴포넌트를 사용하는 게 맞다고 피드백 해주셨으나 이번 브랜치에서는 해당 부분 수정 없이 회원가입 페이지의 UI만 추가하고자 합니다. 이후 아래와 같은 순서로 작업 진행할 예정입니다.
  - 로그인, 회원가입 페이지 폼 유효성 검사 추가
  - 로그인, 회원가입 msw 적용
  - 로그인 여부에 따른 헤더 UI 수정 및 헤더 NavList, NavComponent 리팩토링

### 스크린 샷

<img width="1905" height="1930" alt="localhost_5173_auth_signup" src="https://github.com/user-attachments/assets/d7409216-ca67-4962-9981-cec29468be67" />

## 🔗 연관된 이슈

> closes #82
