### PR TITLE
Fix: 북마크한 공고 및 강의 fetch 방식 변경

### DIFF
--- a/src/hooks/api/useBookmarkedLecture.ts
+++ b/src/hooks/api/useBookmarkedLecture.ts
@@ -4,15 +4,19 @@ import api from '@/utils/axios'
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 export default function useBookmarkedLectures(
-  searchParam: string = '',
+  searchParam?: URLSearchParams,
   options?: UseQueryOptions<BookmarkedLectures>
 ) {
   return useQuery<BookmarkedLectures>({
-    queryKey: ['lectures', 'bookmarks', searchParam],
+    queryKey: [
+      'lectures',
+      'bookmarks',
+      searchParam ? searchParam.toString() : '',
+    ],
     queryFn: async () => {
-      const res = await api.get(
-        `${API_BASE_URL}/lectures/bookmarks?${searchParam}`
-      )
+      const res = await api.get(`${API_BASE_URL}/lectures/bookmarks`, {
+        params: searchParam,
+      })
 
       return res.data
     },

--- a/src/hooks/api/useBookmarkedRecruitments.ts
+++ b/src/hooks/api/useBookmarkedRecruitments.ts
@@ -4,13 +4,19 @@ import api from '@/utils/axios'
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 export default function useBookmarkedRecruitment(
-  searchParam: string = '',
+  searchParam?: URLSearchParams,
   options?: UseQueryOptions<BookmarkedRecruitments>
 ) {
   return useQuery<BookmarkedRecruitments>({
-    queryKey: ['recruitment', 'bookmarked', searchParam],
+    queryKey: [
+      'recruitment',
+      'bookmarked',
+      searchParam ? searchParam.toString() : '',
+    ],
     queryFn: async () => {
-      const res = await api.get(`${API_BASE_URL}/recruitments/bookmarks/me`)
+      const res = await api.get(`${API_BASE_URL}/recruitments/bookmarks/me`, {
+        params: searchParam,
+      })
 
       return res.data
     },

--- a/src/pages/my-page/BookmarkedLecture.tsx
+++ b/src/pages/my-page/BookmarkedLecture.tsx
@@ -5,19 +5,22 @@ import BookmarkedLectureCard from '@/components/my-page/bookmarked-lecture/Bookm
 import { useBookmarkedLectures } from '@/hooks/api'
 import { useDebounce } from '@/hooks/useDebounce'
 import { SearchIcon } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
+
 export default function BookmarkedLecture() {
-  const [searchParam, setSearchParam] = useState('')
+  const [search, setSearch] = useState('')
+  const debouncedSearch = useDebounce(search, 250)
 
-  const debouncedSearchParam = useDebounce(searchParam, 250)
+  const searchParams = useMemo(() => {
+    const params = new URLSearchParams()
+    if (debouncedSearch) {
+      params.set('search', debouncedSearch)
+    }
 
-  const { isPending, data, refetch } = useBookmarkedLectures(
-    `search=${debouncedSearchParam}`
-  )
+    return params
+  }, [debouncedSearch])
 
-  useEffect(() => {
-    refetch()
-  }, [debouncedSearchParam, refetch])
+  const { data, isPending } = useBookmarkedLectures(searchParams)
 
   return (
     <div>
@@ -33,8 +36,8 @@ export default function BookmarkedLecture() {
           <Input
             hasIcon
             placeholder="강의명이나 강사명으로 검색..."
-            value={searchParam}
-            onChange={(e) => setSearchParam(e.target.value)}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
           />
         </div>
       </header>

--- a/src/pages/my-page/BookmarkedRecruitment.tsx
+++ b/src/pages/my-page/BookmarkedRecruitment.tsx
@@ -4,20 +4,24 @@ import { BookmarkedRecruitmentCard } from '@/components/my-page'
 import EmptyDataState from '@/components/common/State/EmptyDataState'
 import { useBookmarkedRecruitment } from '@/hooks/api'
 import { useDebounce } from '@/hooks/useDebounce'
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { SearchIcon } from 'lucide-react'
 
 export default function BookmarkedRecruitment() {
-  const [searchParam, setSearchParam] = useState('')
+  const [search, setSearch] = useState('')
 
-  const debouncedSearchParam = useDebounce(searchParam, 250)
+  const debouncedSearch = useDebounce(search, 250)
 
-  const { data, isPending, refetch } =
-    useBookmarkedRecruitment(debouncedSearchParam)
+  const searchParams = useMemo(() => {
+    const params = new URLSearchParams()
+    if (debouncedSearch) {
+      params.set('search', debouncedSearch)
+    }
 
-  useEffect(() => {
-    refetch()
-  }, [debouncedSearchParam, refetch])
+    return params
+  }, [debouncedSearch])
+
+  const { data, isPending } = useBookmarkedRecruitment(searchParams)
 
   return (
     <div>
@@ -35,8 +39,8 @@ export default function BookmarkedRecruitment() {
               hasIcon
               placeholder="공고 제목으로 검색..."
               className="w-full max-w-80"
-              value={searchParam}
-              onChange={(e) => setSearchParam(e.target.value)}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
             />
           </div>
         </div>


### PR DESCRIPTION
## 🚀 PR 요약

> 북마크한 공고 및 강의 fetch 방식 변경

## ✏️ 변경 유형

- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- useBookmarkedLectures와 useBookmarkedRecruitments의 searchParam 파라미터의 타입을 문자열에서 URLSearchParams로 변경

### 참고 사항

- ㅇㅇㅇ은 다음 작업에서 추가 예정

### 스크린 샷

> 화면을 새로 추가했거나 이전과 변화가 있을 경우 추가

## 🔗 연관된 이슈

> closes #152 
