### PR TITLE
Feature: 로그인 & 회원가입 페이지 유효성 검사 적용

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,6 @@
 //hooks
 import useToast from '@/hooks/useToast'
+import { useInterval } from '@/hooks/useInterval'
+import { useTimer } from '@/hooks/useTimer'
 
-export { useToast }
+export { useToast, useInterval, useTimer }

--- a/src/hooks/useInterval.tsx
+++ b/src/hooks/useInterval.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react'
+
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef<() => void | null>(null)
+
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    const tick = () => {
+      savedCallback.current?.()
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay)
+      return () => clearInterval(id)
+    }
+  }, [delay])
+}

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,0 +1,45 @@
+import { useRef, useState } from 'react'
+import { useInterval } from './useInterval'
+
+export function useTimer(defaultMs = 1800000) {
+  const [remainSecond, setRemainSecond] = useState(0)
+  const [isCounting, setIsCounting] = useState(false)
+  const endAtRef = useRef(0)
+
+  const startTimer = (ms = defaultMs) => {
+    endAtRef.current = Date.now() + ms
+    setIsCounting(true)
+    const leftSecond = Math.max(
+      0,
+      Math.ceil((endAtRef.current - Date.now()) / 1000)
+    )
+    setRemainSecond(leftSecond)
+  }
+
+  const resetTimer = () => {
+    setIsCounting(false)
+    endAtRef.current = 0
+    setRemainSecond(0)
+  }
+
+  useInterval(
+    () => {
+      if (!isCounting) return
+      const leftSecond = Math.max(
+        0,
+        Math.ceil((endAtRef.current - Date.now()) / 1000)
+      )
+      setRemainSecond(leftSecond)
+      if (leftSecond === 0) resetTimer()
+    },
+    isCounting ? 1000 : null
+  )
+
+  const formatMMSS = (second: number) => {
+    const mm = Math.floor(second / 60)
+    const ss = String(second % 60).padStart(2, '0')
+    return `${mm}:${ss}`
+  }
+
+  return { remainSecond, isCounting, startTimer, resetTimer, formatMMSS }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,16 +7,39 @@ import {
   AuthSubmitButton,
   AuthTitle,
 } from '@/components/auth'
-import { Input } from '@/components/common/input'
+import { Input, InputErrorMessage } from '@/components/common/input'
 import KakaoIcon from '@/assets/images/KakaoIcon.svg'
 import NaverIcon from '@/assets/images/NaverIcon.svg'
-import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  loginSchema,
+  type LoginSchemaType,
+} from '@/schemas/form-schema/auth-schema'
+import { useToast } from '@/hooks'
+import { useNavigate } from 'react-router'
 
 const flexStyle = 'flex flex-col gap-3'
 
 function Login() {
-  const [idInputValue, setIdInputValue] = useState('')
-  const [passwordInputValue, setPasswordInputValue] = useState('')
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors, isSubmitting },
+    reset,
+  } = useForm<LoginSchemaType>({
+    mode: 'onChange',
+    resolver: zodResolver(loginSchema),
+  })
+  const { triggerToast } = useToast()
+  const navigate = useNavigate()
+
+  const onSubmit = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    triggerToast('success', '로그인이 완료되었습니다!')
+    reset()
+    navigate('/')
+  }
 
   return (
     <AuthContainer className="flex flex-col gap-10">
@@ -39,28 +62,34 @@ function Login() {
           네이버 간편 로그인 / 가입
         </AuthSocialLoginButton>
       </div>
-      <div className={flexStyle}>
+
+      <form className={flexStyle} onSubmit={handleSubmit(onSubmit)}>
         <Input
+          {...register('email')}
           type="email"
           placeholder="아이디 (example@gmail.com)"
-          value={idInputValue}
-          onChange={(event) => setIdInputValue(event.target.value)}
         />
+        {errors.email && (
+          <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
+        )}
         <Input
+          {...register('password')}
           type="password"
           placeholder="비밀번호 (8~15자의 영문 대소문자, 숫자, 특수문자 포함)"
-          value={passwordInputValue}
-          onChange={(event) => setPasswordInputValue(event.target.value)}
         />
+        {errors.password && (
+          <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
+        )}
+
         <div className="flex gap-2">
           <AuthLink to="/auth/find-email">아이디 찾기</AuthLink>
           <span className="text-primary-600">|</span>
           <AuthLink to="/auth/find-password">비밀번호 찾기</AuthLink>
         </div>
-        <AuthSubmitButton disabled={!idInputValue || !passwordInputValue}>
+        <AuthSubmitButton disabled={!isValid || isSubmitting}>
           일반회원 로그인
         </AuthSubmitButton>
-      </div>
+      </form>
     </AuthContainer>
   )
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -19,6 +19,7 @@ import {
   authSchema,
   type AuthSchemaType,
 } from '@/schemas/form-schema/auth-schema'
+import { cn } from '@/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -178,7 +179,7 @@ function Signup() {
           <div className={flexRowStyle}>
             <Input {...register('email')} placeholder="이메일을 입력해주세요" />
             <AuthVerifyButton
-              className="w-39 p-0"
+              className={cn(timer.email.isCounting && 'w-44 p-0')}
               disabled={isEmailNotValid || timer.email.isCounting}
               onClick={() => handleCodeSend('email')}
             >
@@ -215,6 +216,7 @@ function Signup() {
               placeholder="휴대전화 번호를 입력해주세요 (ex. 01012345678)"
             />
             <AuthVerifyButton
+              className={cn(timer.phoneNumber.isCounting && 'w-44 p-0')}
               disabled={isPhoneNumberNotValid || timer.phoneNumber.isCounting}
               onClick={() => handleCodeSend('phoneNumber')}
             >

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -8,12 +8,87 @@ import {
   AuthTitle,
   AuthVerifyButton,
 } from '@/components/auth'
-import { Input, InputDescription, InputLabel } from '@/components/common/input'
+import {
+  Input,
+  InputDescription,
+  InputErrorMessage,
+  InputLabel,
+} from '@/components/common/input'
+import { useTimer, useToast } from '@/hooks'
+import {
+  authSchema,
+  type AuthSchemaType,
+} from '@/schemas/form-schema/auth-schema'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router'
 
 const flexRowStyle = 'flex gap-3'
 const flexColStyle = 'flex flex-col gap-3'
 
 function Signup() {
+  const [isDuplicateChecked, setIsDuplicateChecked] = useState(false)
+  const [isCodeSent, SetIsCodeSent] = useState({
+    email: false,
+    phoneNumber: false,
+  })
+  const [isCodeVerified, SetIsCodeVerified] = useState({
+    email: false,
+    phoneNumber: false,
+  })
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors, isSubmitting },
+    reset,
+    watch,
+    getFieldState,
+  } = useForm<AuthSchemaType>({
+    mode: 'onChange',
+    resolver: zodResolver(authSchema),
+  })
+  const navigate = useNavigate()
+  const { triggerToast } = useToast()
+  const timer = {
+    email: useTimer(180000),
+    phoneNumber: useTimer(180000),
+  }
+
+  const onSubmit = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    triggerToast('success', '회원가입이 완료되었습니다!')
+    reset()
+    navigate('/auth/login')
+  }
+
+  const isNicknameNotValid =
+    getFieldState('nickname').invalid || !watch('nickname')
+  const isEmailNotValid = getFieldState('email').invalid || !watch('email')
+  const isPhoneNumberNotValid =
+    getFieldState('phoneNumber').invalid || !watch('phoneNumber')
+
+  const handleDuplicateCheck = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    setIsDuplicateChecked(true)
+    triggerToast('success', '사용 가능한 닉네임입니다.')
+  }
+
+  const handleCodeSend = async (label: 'email' | 'phoneNumber') => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
+    timer[label].startTimer()
+    triggerToast('success', '인증 코드를 전송했습니다.')
+  }
+
+  const handleCodeVerify = async (label: 'email' | 'phoneNumber') => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
+    SetIsCodeSent((prev) => ({ ...prev, [label]: false }))
+    timer[label].resetTimer()
+    triggerToast('success', '인증을 완료했습니다!')
+  }
+
   return (
     <AuthContainer className="flex flex-col gap-10">
       <div className={flexColStyle}>
@@ -24,70 +99,150 @@ function Signup() {
           <AuthLink to="/auth/login">로그인하기</AuthLink>
         </div>
       </div>
-      <form className="flex flex-col gap-10">
+      <form className="flex flex-col gap-10" onSubmit={handleSubmit(onSubmit)}>
+        {/* 이름 */}
         <div className={flexColStyle}>
           <InputLabel isRequired>이름</InputLabel>
-          <Input placeholder="이름을 입력해주세요" />
+          <Input {...register('name')} placeholder="이름을 입력해주세요" />
+          {errors.name && (
+            <InputErrorMessage>{`${errors.name.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 닉네임 */}
         <div className={flexColStyle}>
           <InputLabel isRequired>닉네임</InputLabel>
           <div className={flexRowStyle}>
-            <Input placeholder="닉네임을 입력해주세요" />
-            <AuthVerifyButton>중복확인</AuthVerifyButton>
+            <Input
+              {...register('nickname')}
+              placeholder="닉네임을 입력해주세요"
+            />
+            <AuthVerifyButton
+              disabled={isNicknameNotValid}
+              onClick={handleDuplicateCheck}
+            >
+              중복확인
+            </AuthVerifyButton>
           </div>
+          {errors.nickname && (
+            <InputErrorMessage>{`${errors.nickname.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 생년월일 */}
         <div className={flexColStyle}>
           <InputLabel isRequired>생년월일</InputLabel>
-          <Input placeholder="생년월일을 입력해주세요 (ex. 20001004)" />
+          <Input
+            {...register('birthday')}
+            placeholder="생년월일을 입력해주세요 (ex. 20001004)"
+          />
+          {errors.birthday && (
+            <InputErrorMessage>{`${errors.birthday.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 성별 */}
         <div className={flexColStyle}>
           <InputLabel isRequired>성별</InputLabel>
           <div className={flexRowStyle}>
             <label htmlFor="gender-male">
-              <AuthBadge isSelected>남</AuthBadge>
+              <AuthBadge isSelected={watch('gender') === 'male'}>남</AuthBadge>
             </label>
             <input
               id="gender-male"
               type="radio"
               value="male"
               className="hidden"
+              {...register('gender')}
             />
             <label htmlFor="gender-female">
-              <AuthBadge>여</AuthBadge>
+              <AuthBadge isSelected={watch('gender') === 'female'}>
+                여
+              </AuthBadge>
             </label>
             <input
               id="gender-female"
               type="radio"
               value="female"
               className="hidden"
+              {...register('gender')}
             />
           </div>
+          {errors.gender && (
+            <InputErrorMessage>{`${errors.gender.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 이메일 */}
         <div className={flexColStyle}>
           <div className="flex gap-3">
             <InputLabel isRequired>이메일</InputLabel>
             <InputDescription>로그인 시 아이디로 사용합니다.</InputDescription>
           </div>
           <div className={flexRowStyle}>
-            <Input placeholder="이메일을 입력해주세요" />
-            <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+            <Input {...register('email')} placeholder="이메일을 입력해주세요" />
+            <AuthVerifyButton
+              className="w-39 p-0"
+              disabled={isEmailNotValid || timer.email.isCounting}
+              onClick={() => handleCodeSend('email')}
+            >
+              {timer.email.isCounting
+                ? `재전송 (${timer.email.formatMMSS(timer.email.remainSecond)})`
+                : '인증코드전송'}
+            </AuthVerifyButton>
           </div>
+          {errors.email && (
+            <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
+          )}
           <div className={flexRowStyle}>
-            <Input placeholder="인증코드 6자리를 입력해주세요" />
-            <AuthVerifyButton disabled>인증코드확인</AuthVerifyButton>
+            <Input
+              {...register('verificationCode.email')}
+              placeholder="인증코드 6자리를 입력해주세요"
+            />
+            <AuthVerifyButton
+              disabled={!isCodeSent.email}
+              onClick={() => handleCodeVerify('email')}
+            >
+              인증코드확인
+            </AuthVerifyButton>
           </div>
+          {errors.verificationCode?.email && (
+            <InputErrorMessage>{`${errors.verificationCode.email.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 휴대전화 */}
         <div className={flexColStyle}>
           <InputLabel isRequired>휴대전화</InputLabel>
           <div className="flex gap-3">
-            <Input placeholder="휴대전화 번호를 입력해주세요 (ex. 01012345678)" />
-            <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+            <Input
+              {...register('phoneNumber')}
+              placeholder="휴대전화 번호를 입력해주세요 (ex. 01012345678)"
+            />
+            <AuthVerifyButton
+              disabled={isPhoneNumberNotValid || timer.phoneNumber.isCounting}
+              onClick={() => handleCodeSend('phoneNumber')}
+            >
+              {timer.phoneNumber.isCounting
+                ? `재전송 (${timer.phoneNumber.formatMMSS(timer.phoneNumber.remainSecond)})`
+                : '인증코드전송'}
+            </AuthVerifyButton>
           </div>
+          {errors.phoneNumber && (
+            <InputErrorMessage>{`${errors.phoneNumber.message}`}</InputErrorMessage>
+          )}
           <div className={flexRowStyle}>
-            <Input placeholder="인증코드 6자리를 입력해주세요" />
-            <AuthVerifyButton disabled>인증코드확인</AuthVerifyButton>
+            <Input
+              {...register('verificationCode.phoneNumber')}
+              placeholder="인증코드 6자리를 입력해주세요"
+            />
+            <AuthVerifyButton
+              disabled={!isCodeSent.phoneNumber}
+              onClick={() => handleCodeVerify('phoneNumber')}
+            >
+              인증코드확인
+            </AuthVerifyButton>
           </div>
+          {errors.verificationCode?.phoneNumber && (
+            <InputErrorMessage>{`${errors.verificationCode.phoneNumber.message}`}</InputErrorMessage>
+          )}
         </div>
+        {/* 비밀번호 */}
         <div className={flexColStyle}>
           <div className={flexRowStyle}>
             <InputLabel isRequired>비밀번호</InputLabel>
@@ -95,10 +250,39 @@ function Signup() {
               8~15자의 영문 대소문자, 숫자, 특수문자 포함
             </InputDescription>
           </div>
-          <Input placeholder="비밀번호를 입력해주세요" />
-          <Input placeholder="비밀번호를 다시 입력해주세요" />
+          <div className={flexColStyle}>
+            <Input
+              {...register('password')}
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+            />
+            {errors.password && (
+              <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
+            )}
+          </div>
+          <div className={flexColStyle}>
+            <Input
+              {...register('confirmPassword')}
+              type="password"
+              placeholder="비밀번호를 다시 입력해주세요"
+            />
+            {errors.confirmPassword && (
+              <InputErrorMessage>{`${errors.confirmPassword.message}`}</InputErrorMessage>
+            )}
+          </div>
         </div>
-        <AuthSubmitButton>가입하기</AuthSubmitButton>
+        {/* 가입하기 버튼 */}
+        <AuthSubmitButton
+          disabled={
+            !isValid ||
+            isSubmitting ||
+            !isDuplicateChecked ||
+            !isCodeVerified.email ||
+            !isCodeVerified.phoneNumber
+          }
+        >
+          가입하기
+        </AuthSubmitButton>
       </form>
     </AuthContainer>
   )

--- a/src/schemas/form-schema/auth-schema.ts
+++ b/src/schemas/form-schema/auth-schema.ts
@@ -41,10 +41,16 @@ export const authSchema = z
         /^010\d{8}$/,
         '휴대전화 번호는 하이픈(-) 없이 010으로 시작하는 11자리여야 합니다'
       ),
-    verificationCode: z
-      .string()
-      .min(1, '인증코드는 필수로 입력해야 합니다')
-      .length(6, '인증코드는 6자리(숫자 + 영문)로 입력해주세요'),
+    verificationCode: z.object({
+      email: z
+        .string()
+        .min(1, '인증코드는 필수로 입력해야 합니다')
+        .length(6, '인증코드는 6자리(숫자 + 영문)로 입력해주세요'),
+      phoneNumber: z
+        .string()
+        .min(1, '인증코드는 필수로 입력해야 합니다')
+        .length(6, '인증코드는 6자리(숫자 + 영문)로 입력해주세요'),
+    }),
     gender: z.enum(['male', 'female'], '성별을 선택해주세요'),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -53,3 +59,7 @@ export const authSchema = z
   })
 
 export type AuthSchemaType = z.infer<typeof authSchema>
+
+export const loginSchema = authSchema.pick({ email: true, password: true })
+
+export type LoginSchemaType = z.infer<typeof loginSchema>

--- a/src/tests/AuthFormVerificationTest.tsx
+++ b/src/tests/AuthFormVerificationTest.tsx
@@ -106,10 +106,10 @@ function AuthFormVerificationTest() {
         <div className="flex flex-col gap-2">
           <InputLabel isRequired>인증번호</InputLabel>
           <Input
-            {...register('verificationCode')}
+            {...register('verificationCode.email')}
             placeholder="인증번호 6자리를 입력해주세요"
           />
-          {errors.verificationCode && (
+          {errors.verificationCode?.email && (
             <InputErrorMessage>{`${errors.verificationCode.message}`}</InputErrorMessage>
           )}
         </div>


### PR DESCRIPTION
## 🚀 PR 요약

로그인 & 회원가입 페이지에 폼 유효성 검사를 적용했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그인 페이지 폼 유효성 검사 추가
- 회원가입 페이지 폼 유효성 검사 추가
  - `useInterval`, `useTimer` 훅 추가하여 **AuthVerifyButton**에 적용

### 참고 사항

- **AuthVerifyButton**, **AuthSubmitButton**을 클릭했을 때 실제로 동작하는 것처럼 보이기 위해 setTimeout을 이용해 클릭 시 약간 지연되도록 했습니다.
- 현재는 인증코드 확인 api 연결이 되어있지 않아서 아무 값 6자리만 입력해도 성공 처리되는데, 이후 코드가 틀리면 에러 토스트 메시지를 띄우도록 추가하겠습니다.
- 모바일 화면일 때를 확인해봤는데, 토스트 메시지가 반응형 적용이 되어 있지 않은 것을 알게 되어서 이슈 추가 후 수정 예정입니다.

### 스크린 샷

**일반 사이즈 화면**

https://github.com/user-attachments/assets/efd2879f-5c9e-4e09-991b-ac757dc6b377

**모바일 사이즈 화면**

<img width="250" alt="localhost_5173_auth_signup(iPhone SE) (1)" src="https://github.com/user-attachments/assets/5c5d95e8-5bb0-4f32-bbb5-dcf98d9a7986" />

## 🔗 연관된 이슈

> closes #123 
