### PR TITLE
Feature: 이메일 찾기 & 비밀번호 찾기 공용 컴포넌트 추가

### DIFF
--- a/src/components/auth/AuthIcon.tsx
+++ b/src/components/auth/AuthIcon.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/utils'
+import type { LucideIcon } from 'lucide-react'
+
+interface AuthIconProps {
+  Icon: LucideIcon
+  iconClassName?: string
+}
+
+function AuthIcon({ Icon, iconClassName }: AuthIconProps) {
+  return (
+    <div className="flex size-16 items-center justify-center rounded-full bg-amber-100">
+      <Icon className={cn('text-primary-500 h-6', iconClassName)} />
+    </div>
+  )
+}
+
+export default AuthIcon

--- a/src/components/auth/AuthStep.tsx
+++ b/src/components/auth/AuthStep.tsx
@@ -1,15 +1,23 @@
 import { cn } from '@/utils'
+import { Fragment } from 'react/jsx-runtime'
 
-const isStepReached = (stepIndex, currentIndex) => stepIndex <= currentIndex
+const isStepReached = (stepIndex: number, currentIndex: number) =>
+  stepIndex <= currentIndex
 
-function AuthStepDot({ stepIndex, currentIndex }) {
+function AuthStepDot({
+  stepIndex,
+  currentIndex,
+}: {
+  stepIndex: number
+  currentIndex: number
+}) {
   return (
     <div
       className={cn(
         'flex size-8 items-center justify-center rounded-full transition-colors duration-200 ease-out',
         isStepReached(stepIndex, currentIndex)
-          ? 'bg-primary-500'
-          : 'bg-gray-200'
+          ? 'bg-primary-500 text-white'
+          : 'bg-gray-200 text-gray-500'
       )}
     >
       {stepIndex}
@@ -17,7 +25,13 @@ function AuthStepDot({ stepIndex, currentIndex }) {
   )
 }
 
-function AuthStepLine({ stepIndex, currentIndex }) {
+function AuthStepLine({
+  stepIndex,
+  currentIndex,
+}: {
+  stepIndex: number
+  currentIndex: number
+}) {
   return (
     <div
       className={cn(
@@ -30,14 +44,25 @@ function AuthStepLine({ stepIndex, currentIndex }) {
   )
 }
 
-function AuthStep({ currentIndex }) {
+function AuthStep({
+  totalIndex,
+  currentIndex,
+}: {
+  totalIndex: number
+  currentIndex: number
+}) {
+  const steps = Array.from({ length: totalIndex }, (_, idx) => idx + 1)
+
   return (
     <div className="flex items-center gap-2">
-      <AuthStepDot stepIndex="1" currentIndex={currentIndex} />
-      <AuthStepLine stepIndex="2" currentIndex={currentIndex} />
-      <AuthStepDot stepIndex="2" currentIndex={currentIndex} />
-      <AuthStepLine stepIndex="3" currentIndex={currentIndex} />
-      <AuthStepDot stepIndex="3" currentIndex={currentIndex} />
+      {steps.map((step) => (
+        <Fragment key={step}>
+          {step > 1 && (
+            <AuthStepLine stepIndex={step} currentIndex={currentIndex} />
+          )}
+          <AuthStepDot stepIndex={step} currentIndex={currentIndex} />
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/src/components/auth/AuthStep.tsx
+++ b/src/components/auth/AuthStep.tsx
@@ -1,21 +1,21 @@
 import { cn } from '@/utils'
 import { Fragment } from 'react/jsx-runtime'
 
-const isStepReached = (stepIndex: number, currentIndex: number) =>
-  stepIndex <= currentIndex
+const isStepReached = (stepIndex: number, currentStep: number) =>
+  stepIndex <= currentStep
 
 function AuthStepDot({
   stepIndex,
-  currentIndex,
+  currentStep,
 }: {
   stepIndex: number
-  currentIndex: number
+  currentStep: number
 }) {
   return (
     <div
       className={cn(
         'flex size-8 items-center justify-center rounded-full transition-colors duration-200 ease-out',
-        isStepReached(stepIndex, currentIndex)
+        isStepReached(stepIndex, currentStep)
           ? 'bg-primary-500 text-white'
           : 'bg-gray-200 text-gray-500'
       )}
@@ -27,40 +27,38 @@ function AuthStepDot({
 
 function AuthStepLine({
   stepIndex,
-  currentIndex,
+  currentStep,
 }: {
   stepIndex: number
-  currentIndex: number
+  currentStep: number
 }) {
   return (
     <div
       className={cn(
         'h-1 flex-1 rounded-sm transition-colors duration-200 ease-out',
-        isStepReached(stepIndex, currentIndex)
-          ? 'bg-primary-500'
-          : 'bg-gray-200'
+        isStepReached(stepIndex, currentStep) ? 'bg-primary-500' : 'bg-gray-200'
       )}
     />
   )
 }
 
 function AuthStep({
-  totalIndex,
-  currentIndex,
+  totalStep,
+  currentStep,
 }: {
-  totalIndex: number
-  currentIndex: number
+  totalStep: number
+  currentStep: number
 }) {
-  const steps = Array.from({ length: totalIndex }, (_, idx) => idx + 1)
+  const steps = Array.from({ length: totalStep }, (_, idx) => idx + 1)
 
   return (
     <div className="flex items-center gap-2">
       {steps.map((step) => (
         <Fragment key={step}>
           {step > 1 && (
-            <AuthStepLine stepIndex={step} currentIndex={currentIndex} />
+            <AuthStepLine stepIndex={step} currentStep={currentStep} />
           )}
-          <AuthStepDot stepIndex={step} currentIndex={currentIndex} />
+          <AuthStepDot stepIndex={step} currentStep={currentStep} />
         </Fragment>
       ))}
     </div>

--- a/src/components/auth/AuthStep.tsx
+++ b/src/components/auth/AuthStep.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/utils'
+
+const isStepReached = (stepIndex, currentIndex) => stepIndex <= currentIndex
+
+function AuthStepDot({ stepIndex, currentIndex }) {
+  return (
+    <div
+      className={cn(
+        'flex size-8 items-center justify-center rounded-full transition-colors duration-200 ease-out',
+        isStepReached(stepIndex, currentIndex)
+          ? 'bg-primary-500'
+          : 'bg-gray-200'
+      )}
+    >
+      {stepIndex}
+    </div>
+  )
+}
+
+function AuthStepLine({ stepIndex, currentIndex }) {
+  return (
+    <div
+      className={cn(
+        'h-1 flex-1 rounded-sm transition-colors duration-200 ease-out',
+        isStepReached(stepIndex, currentIndex)
+          ? 'bg-primary-500'
+          : 'bg-gray-200'
+      )}
+    />
+  )
+}
+
+function AuthStep({ currentIndex }) {
+  return (
+    <div className="flex items-center gap-2">
+      <AuthStepDot stepIndex="1" currentIndex={currentIndex} />
+      <AuthStepLine stepIndex="2" currentIndex={currentIndex} />
+      <AuthStepDot stepIndex="2" currentIndex={currentIndex} />
+      <AuthStepLine stepIndex="3" currentIndex={currentIndex} />
+      <AuthStepDot stepIndex="3" currentIndex={currentIndex} />
+    </div>
+  )
+}
+
+export default AuthStep

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,5 +2,6 @@
 import useToast from '@/hooks/useToast'
 import { useInterval } from '@/hooks/useInterval'
 import { useTimer } from '@/hooks/useTimer'
+import useCode from '@/hooks/useCode'
 
-export { useToast, useInterval, useTimer }
+export { useToast, useInterval, useTimer, useCode }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,6 @@
 import useToast from '@/hooks/useToast'
 import { useInterval } from '@/hooks/useInterval'
 import { useTimer } from '@/hooks/useTimer'
-import useCode from '@/hooks/useCode'
+import useVerificationCode from '@/hooks/useVerificationCode'
 
-export { useToast, useInterval, useTimer, useCode }
+export { useToast, useInterval, useTimer, useVerificationCode }

--- a/src/hooks/useCode.tsx
+++ b/src/hooks/useCode.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useTimer } from './useTimer'
+import useToast from './useToast'
+
+function useCode() {
+  const [isCodeSent, SetIsCodeSent] = useState({
+    email: false,
+    phoneNumber: false,
+  })
+  const [isCodeVerified, SetIsCodeVerified] = useState({
+    email: false,
+    phoneNumber: false,
+  })
+  const timer = {
+    email: useTimer(180000),
+    phoneNumber: useTimer(180000),
+  }
+  const { triggerToast } = useToast()
+
+  const handleCodeSend = async (label: 'email' | 'phoneNumber') => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
+    timer[label].startTimer()
+    triggerToast('success', '인증 코드를 전송했습니다.')
+  }
+
+  const handleCodeVerify = async (label: 'email' | 'phoneNumber') => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
+    SetIsCodeSent((prev) => ({ ...prev, [label]: false }))
+    timer[label].resetTimer()
+    triggerToast('success', '인증을 완료했습니다!')
+  }
+
+  return { isCodeSent, isCodeVerified, timer, handleCodeSend, handleCodeVerify }
+}
+
+export default useCode

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { useInterval } from './useInterval'
 
-export function useTimer(defaultMs = 1800000) {
+export function useTimer(defaultMs = 1800000, onExpire: () => void) {
   const [remainSecond, setRemainSecond] = useState(0)
   const [isCounting, setIsCounting] = useState(false)
   const endAtRef = useRef(0)
@@ -30,7 +30,10 @@ export function useTimer(defaultMs = 1800000) {
         Math.ceil((endAtRef.current - Date.now()) / 1000)
       )
       setRemainSecond(leftSecond)
-      if (leftSecond === 0) resetTimer()
+      if (leftSecond === 0) {
+        onExpire?.()
+        resetTimer()
+      }
     },
     isCounting ? 1000 : null
   )

--- a/src/hooks/useVerificationCode.tsx
+++ b/src/hooks/useVerificationCode.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react'
 import { useTimer } from './useTimer'
 import useToast from './useToast'
 
-function useCode() {
+const TIMER_DURATION_MS = 180000
+
+function useVerificationCode() {
+  const { triggerToast } = useToast()
+
   const [isCodeSent, SetIsCodeSent] = useState({
     email: false,
     phoneNumber: false,
@@ -12,10 +16,19 @@ function useCode() {
     phoneNumber: false,
   })
   const timer = {
-    email: useTimer(180000),
-    phoneNumber: useTimer(180000),
+    email: useTimer(TIMER_DURATION_MS, () =>
+      triggerToast(
+        'warning',
+        '이메일 인증 시간이 만료되었습니다. 다시 시도해주세요.'
+      )
+    ),
+    phoneNumber: useTimer(TIMER_DURATION_MS, () =>
+      triggerToast(
+        'warning',
+        '휴대전화 번호 인증 시간이 만료되었습니다. 다시 시도해주세요.'
+      )
+    ),
   }
-  const { triggerToast } = useToast()
 
   const handleCodeSend = async (label: 'email' | 'phoneNumber') => {
     await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -35,4 +48,4 @@ function useCode() {
   return { isCodeSent, isCodeVerified, timer, handleCodeSend, handleCodeVerify }
 }
 
-export default useCode
+export default useVerificationCode

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -15,7 +15,7 @@ import {
   InputLabel,
   PasswordInput,
 } from '@/components/common/input'
-import { useTimer, useToast } from '@/hooks'
+import { useCode, useToast } from '@/hooks'
 import {
   authSchema,
   type AuthSchemaType,
@@ -31,14 +31,6 @@ const flexColStyle = 'flex flex-col gap-3'
 
 function Signup() {
   const [isDuplicateChecked, setIsDuplicateChecked] = useState(false)
-  const [isCodeSent, SetIsCodeSent] = useState({
-    email: false,
-    phoneNumber: false,
-  })
-  const [isCodeVerified, SetIsCodeVerified] = useState({
-    email: false,
-    phoneNumber: false,
-  })
   const {
     register,
     handleSubmit,
@@ -52,10 +44,13 @@ function Signup() {
   })
   const navigate = useNavigate()
   const { triggerToast } = useToast()
-  const timer = {
-    email: useTimer(180000),
-    phoneNumber: useTimer(180000),
-  }
+  const {
+    isCodeSent,
+    isCodeVerified,
+    timer,
+    handleCodeSend,
+    handleCodeVerify,
+  } = useCode()
 
   const onSubmit = async () => {
     await new Promise((resolve) => setTimeout(resolve, 500))
@@ -74,21 +69,6 @@ function Signup() {
     await new Promise((resolve) => setTimeout(resolve, 1000))
     setIsDuplicateChecked(true)
     triggerToast('success', '사용 가능한 닉네임입니다.')
-  }
-
-  const handleCodeSend = async (label: 'email' | 'phoneNumber') => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
-    timer[label].startTimer()
-    triggerToast('success', '인증 코드를 전송했습니다.')
-  }
-
-  const handleCodeVerify = async (label: 'email' | 'phoneNumber') => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
-    SetIsCodeSent((prev) => ({ ...prev, [label]: false }))
-    timer[label].resetTimer()
-    triggerToast('success', '인증을 완료했습니다!')
   }
 
   return (

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -15,7 +15,7 @@ import {
   InputLabel,
   PasswordInput,
 } from '@/components/common/input'
-import { useCode, useToast } from '@/hooks'
+import { useToast, useVerificationCode } from '@/hooks'
 import {
   authSchema,
   type AuthSchemaType,
@@ -50,7 +50,7 @@ function Signup() {
     timer,
     handleCodeSend,
     handleCodeVerify,
-  } = useCode()
+  } = useVerificationCode()
 
   const onSubmit = async () => {
     await new Promise((resolve) => setTimeout(resolve, 500))

--- a/src/pages/TestHub.tsx
+++ b/src/pages/TestHub.tsx
@@ -15,7 +15,7 @@ function TestHub() {
 
   return (
     <main className="flex h-dvh">
-      <aside className="bg-gray-200 p-10">
+      <aside className="overflow-auto bg-gray-200 p-10">
         <h2 className="py-5 text-center text-2xl font-bold">Test Hub</h2>
         <div className="flex flex-col gap-5">
           {testPages &&

--- a/src/schemas/form-schema/find-email-schema.ts
+++ b/src/schemas/form-schema/find-email-schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import { authSchema } from './auth-schema'
+
+export const FindEmailStep1Schema = authSchema.pick({
+  name: true,
+  phoneNumber: true,
+})
+
+export type FindEmailStep1Type = z.infer<typeof FindEmailStep1Schema>
+
+export const FindEmailStep2Schema = z.object({
+  code: z
+    .string()
+    .min(1, '인증코드는 필수로 입력해야 합니다')
+    .length(6, '인증코드는 6자리(숫자 + 영문)로 입력해주세요'),
+})
+
+export type FindEmailStep2Type = z.infer<typeof FindEmailStep2Schema>

--- a/src/tests/StepTest.tsx
+++ b/src/tests/StepTest.tsx
@@ -1,7 +1,154 @@
+import { Button } from '@/components'
+import { AuthSubmitButton, AuthVerifyButton } from '@/components/auth'
 import AuthStep from '@/components/auth/AuthStep'
+import { Input, InputErrorMessage } from '@/components/common/input'
+import { useCode } from '@/hooks'
+import {
+  FindEmailStep1Schema,
+  FindEmailStep2Schema,
+  type FindEmailStep1Type,
+  type FindEmailStep2Type,
+} from '@/schemas/form-schema/find-email-schema'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect, useState } from 'react'
+import { useForm, type DefaultValues } from 'react-hook-form'
+
+interface FirstStepProps {
+  defaultValues: DefaultValues<FindEmailStep1Type>
+  onNext: (value: FindEmailStep1Type) => void
+}
+
+function FirstStep({ defaultValues, onNext }: FirstStepProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<FindEmailStep1Type>({
+    mode: 'onChange',
+    resolver: zodResolver(FindEmailStep1Schema),
+    defaultValues,
+  })
+
+  const onSubmit = (value: FindEmailStep1Type) => onNext(value)
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <Input placeholder="이름" {...register('name')} />
+      {errors.name && (
+        <InputErrorMessage>{`${errors.name.message}`}</InputErrorMessage>
+      )}
+      <Input placeholder="휴대전화 번호" {...register('phoneNumber')} />
+      {errors.phoneNumber && (
+        <InputErrorMessage>{`${errors.phoneNumber.message}`}</InputErrorMessage>
+      )}
+      <AuthSubmitButton disabled={!isValid}>Next</AuthSubmitButton>
+    </form>
+  )
+}
+
+interface SecondStepProps {
+  defaultValues: DefaultValues<FindEmailStep2Type>
+  onPrev: () => void
+  onNext: (value: FindEmailStep2Type) => void
+}
+
+function SecondStep({ defaultValues, onPrev, onNext }: SecondStepProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<FindEmailStep2Type>({
+    mode: 'onChange',
+    resolver: zodResolver(FindEmailStep2Schema),
+    defaultValues,
+  })
+  const { isCodeSent, isCodeVerified, handleCodeSend, handleCodeVerify } =
+    useCode()
+
+  const onSubmit = (value: FindEmailStep2Type) => onNext(value)
+
+  useEffect(() => {
+    handleCodeSend('phoneNumber')
+  }, [])
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <div className="flex gap-2">
+        <Input
+          {...register('code')}
+          placeholder="인증코드 6자리를 입력해주세요"
+        />
+        <AuthVerifyButton
+          disabled={!isCodeSent.phoneNumber}
+          onClick={() => handleCodeVerify('phoneNumber')}
+        >
+          인증코드확인
+        </AuthVerifyButton>
+      </div>
+      {errors.code && (
+        <InputErrorMessage>{`${errors.code.message}`}</InputErrorMessage>
+      )}
+      <AuthSubmitButton disabled={!isValid || !isCodeVerified.phoneNumber}>
+        Next
+      </AuthSubmitButton>
+      <Button variant="outline" onClick={onPrev} className="w-full py-4">
+        Prev
+      </Button>
+    </form>
+  )
+}
 
 function StepTest() {
-  return <AuthStep currentIndex="2" />
+  const [currentStep, setCurrentStep] = useState(1)
+  const [stepHistory, setStepHistory] = useState({
+    step1: { name: '', phoneNumber: '' },
+    step2: { code: '' },
+    step3: { email: '', date: '' },
+  })
+
+  return (
+    <div className="flex flex-col gap-10">
+      <AuthStep totalIndex={3} currentIndex={currentStep} />
+      {currentStep === 1 && (
+        <FirstStep
+          defaultValues={stepHistory.step1}
+          onNext={(value) => {
+            setStepHistory((prev) => ({
+              ...prev,
+              step1: {
+                ...prev.step1,
+                ...value,
+              },
+            }))
+            setCurrentStep(2)
+          }}
+        />
+      )}
+      {currentStep === 2 && (
+        <SecondStep
+          defaultValues={stepHistory.step2}
+          onPrev={() => setCurrentStep(1)}
+          onNext={(value) => {
+            setStepHistory((prev) => ({
+              ...prev,
+              step2: {
+                ...prev.step2,
+                ...value,
+              },
+              step3: {
+                ...prev.step3,
+                email: 'test@test.com',
+              },
+            }))
+            setCurrentStep(3)
+          }}
+        />
+      )}
+      {currentStep === 3 && (
+        <div className="text-center">이메일: {stepHistory.step3.email}</div>
+      )}
+    </div>
+  )
 }
 
 export default StepTest

--- a/src/tests/StepTest.tsx
+++ b/src/tests/StepTest.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components'
 import { AuthSubmitButton, AuthVerifyButton } from '@/components/auth'
 import AuthStep from '@/components/auth/AuthStep'
 import { Input, InputErrorMessage } from '@/components/common/input'
-import { useCode } from '@/hooks'
+import { useVerificationCode } from '@/hooks'
 import {
   FindEmailStep1Schema,
   FindEmailStep2Schema,
@@ -63,7 +63,7 @@ function SecondStep({ defaultValues, onPrev, onNext }: SecondStepProps) {
     defaultValues,
   })
   const { isCodeSent, isCodeVerified, handleCodeSend, handleCodeVerify } =
-    useCode()
+    useVerificationCode()
 
   const onSubmit = (value: FindEmailStep2Type) => onNext(value)
 

--- a/src/tests/StepTest.tsx
+++ b/src/tests/StepTest.tsx
@@ -1,0 +1,7 @@
+import AuthStep from '@/components/auth/AuthStep'
+
+function StepTest() {
+  return <AuthStep currentIndex="2" />
+}
+
+export default StepTest

--- a/src/tests/StepTest.tsx
+++ b/src/tests/StepTest.tsx
@@ -108,7 +108,7 @@ function StepTest() {
 
   return (
     <div className="flex flex-col gap-10">
-      <AuthStep totalIndex={3} currentIndex={currentStep} />
+      <AuthStep totalStep={3} currentStep={currentStep} />
       {currentStep === 1 && (
         <FirstStep
           defaultValues={stepHistory.step1}


### PR DESCRIPTION
## 🚀 PR 요약

이메일 찾기 & 비밀번호 찾기에 공용으로 사용되는 컴포넌트 두 가지를 추가하고, `AuthStep` 관련 테스트 페이지를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `AuthIcon` 추가
  - `Icon`: LucideIcon 아이콘 지정
  - `iconClassName`: 아이콘 스타일 지정
- `AuthStep` 추가
  - `totalIndex`: 전체 단계 수
  - `currentIndex`: 현재 단계 수

### 참고 사항

- `AuthStep`의 `totalIndex` 값에 따라 총 단계 수가 지정됩니다.
- 테스트 페이지는 `AuthStep`이 잘 동작하는 지 확인하기 위해 **이메일 찾기 페이지**를 기반으로 추가했습니다.

### 스크린 샷

**AuthIcon 예시**
<img width="204" height="141" alt="image" src="https://github.com/user-attachments/assets/7eadb1a4-b893-49dc-9c5b-463fba60b940" />


**totalIndex 값에 따라 단계 수 지정**
![StudyHub-Chrome2025-09-1800-08-29-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/5d6bc7cb-0381-4419-aba9-146fd60b1132)

**AuthStep 동작 테스트 (콘솔창 참고)**
![StudyHub-Chrome2025-09-1800-04-05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/eff7a717-5cd2-4943-b66c-6fee6ee0c876)

## 🔗 연관된 이슈

> closes #180
