### PR TITLE
Refactor: 인증 & 인가 처리 방식 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,22 @@
 import TestRoutes from '@/routes/TestRoutes'
-import useAxiosInterceptor from './hooks/api/useAxiosInterceptor'
+import useAxiosInterceptor from '@/hooks/api/useAxiosInterceptor'
+import { useEffect } from 'react'
+import { getAccessToken } from './utils'
+import useTokenRefresh from './hooks/api/auth/useTokenRefresh'
 
 function App() {
+  const refreshToken = useTokenRefresh()
+
+  useEffect(() => {
+    const hasAccessToken = getAccessToken()
+    if (!hasAccessToken) {
+      refreshToken.mutate()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   useAxiosInterceptor()
+
   return <TestRoutes />
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import TestRoutes from '@/routes/TestRoutes'
+import useAxiosInterceptor from './hooks/api/useAxiosInterceptor'
 
 function App() {
+  useAxiosInterceptor()
   return <TestRoutes />
 }
 

--- a/src/constants/api-endpoints.ts
+++ b/src/constants/api-endpoints.ts
@@ -1,0 +1,12 @@
+export const PUBLIC_ENDPOINTS = [
+  'auth/email/login',
+  'users/signup',
+  'auth/kakao/callback',
+  'auth/naver/callback',
+  'email/send-code',
+  'phone/send-code',
+  'auth/email/verify',
+  'auth/verify-phone',
+  'token/refresh',
+  'users/recover-account',
+] as const

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -1,6 +1,7 @@
 import { useToast } from '@/hooks'
 import { useLoginStore } from '@/store/useLoginStore'
 import type { UserLogin } from '@/types/api-request-types/auth-request-types'
+import { setAccessToken } from '@/utils'
 import api from '@/utils/axios'
 import {
   useMutation,
@@ -9,25 +10,28 @@ import {
 } from '@tanstack/react-query'
 
 export default function useLogin(
-  options?: UseMutationOptions<void, Error, UserLogin>
+  options?: UseMutationOptions<string, Error, UserLogin>
 ) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
-  const { setLoggedIn } = useLoginStore()
+  const { setIsLoggedIn } = useLoginStore()
 
-  return useMutation<void, Error, UserLogin>({
+  return useMutation<string, Error, UserLogin>({
+    ...options,
     mutationKey: ['auth', 'email', 'login'],
     mutationFn: async (payload) => {
-      await api.post(`/auth/email/login`, payload)
+      const response = await api.post(`/auth/email/login`, payload)
+      const newAccessToken = response.data.access_token
+      return newAccessToken
     },
-    onSuccess: async () => {
+    onSuccess: async (newAccessToken: string) => {
+      setAccessToken(newAccessToken)
+      setIsLoggedIn(true)
       await qc.invalidateQueries({ queryKey: ['users', 'me'] })
-      setLoggedIn()
-      triggerToast('success', '로그인에 성공했습니다.')
+      triggerToast('success', '로그인이 완료되었습니다.')
     },
     onError: () => {
       triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다.')
     },
-    ...options,
   })
 }

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -1,4 +1,5 @@
-import useToast from '@/hooks/useToast'
+import { useToast } from '@/hooks'
+import { useLoginStore } from '@/store/useLoginStore'
 import type { UserLogin } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import {
@@ -12,6 +13,7 @@ export default function useLogin(
 ) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
+  const { setLoggedIn } = useLoginStore()
 
   return useMutation<void, Error, UserLogin>({
     mutationKey: ['auth', 'email', 'login'],
@@ -20,6 +22,7 @@ export default function useLogin(
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ['users', 'me'] })
+      setLoggedIn()
       triggerToast('success', '로그인에 성공했습니다.')
     },
     onError: () => {

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -20,7 +20,7 @@ export default function useLogin(
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ['users', 'me'] })
-      triggerToast('success', '로그인 성공')
+      triggerToast('success', '로그인에 성공했습니다.')
     },
     onError: () => {
       triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다.')

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,4 +1,6 @@
-import useToast from '@/hooks/useToast'
+import { useToast } from '@/hooks'
+import { useLoginStore } from '@/store/useLoginStore'
+import { clearAccessToken } from '@/utils'
 import api from '@/utils/axios'
 import {
   useMutation,
@@ -9,6 +11,7 @@ import {
 export default function useLogout(options?: UseMutationOptions) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
+  const { setLoggedOut } = useLoginStore()
 
   return useMutation({
     mutationKey: ['users', 'logout'],
@@ -16,6 +19,8 @@ export default function useLogout(options?: UseMutationOptions) {
       await api.post(`/users/logout`)
     },
     onSuccess: () => {
+      setLoggedOut()
+      clearAccessToken()
       qc.removeQueries({ queryKey: ['users', 'me'] })
       triggerToast('success', '로그아웃 성공')
     },

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -15,7 +15,7 @@ export default function useLogout(options?: UseMutationOptions) {
     mutationFn: async () => {
       await api.post(`/users/logout`)
     },
-    onSuccess: async () => {
+    onSuccess: () => {
       qc.removeQueries({ queryKey: ['users', 'me'] })
       triggerToast('success', '로그아웃 성공')
     },

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -11,7 +11,7 @@ import {
 export default function useLogout(options?: UseMutationOptions) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
-  const { setLoggedOut } = useLoginStore()
+  const { setIsLoggedIn } = useLoginStore()
 
   return useMutation({
     mutationKey: ['users', 'logout'],
@@ -19,10 +19,10 @@ export default function useLogout(options?: UseMutationOptions) {
       await api.post(`/users/logout`)
     },
     onSuccess: () => {
-      setLoggedOut()
+      setIsLoggedIn(false)
       clearAccessToken()
       qc.removeQueries({ queryKey: ['users', 'me'] })
-      triggerToast('success', '로그아웃 성공')
+      triggerToast('success', '로그아웃이 완료되었습니다.')
     },
     ...options,
   })

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -1,4 +1,5 @@
 import { useLoginStore } from '@/store/useLoginStore'
+import { setAccessToken } from '@/utils'
 import api from '@/utils/axios'
 import {
   useMutation,
@@ -8,7 +9,7 @@ import {
 
 export default function useTokenRefresh(options?: UseMutationOptions) {
   const qc = useQueryClient()
-  const { setLoggedOut } = useLoginStore()
+  const { setIsLoggedIn } = useLoginStore()
 
   return useMutation({
     ...options,
@@ -18,8 +19,13 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
       const newAccessToken = response.data.access_token
       return newAccessToken
     },
+    onSuccess: (newAccessToken: string) => {
+      setAccessToken(newAccessToken)
+      setIsLoggedIn(true)
+      qc.invalidateQueries({ queryKey: ['users', 'me'] })
+    },
     onError: () => {
-      setLoggedOut()
+      setIsLoggedIn(false)
       qc.removeQueries({ queryKey: ['users', 'me'] })
     },
   })

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -1,0 +1,30 @@
+import useToast from '@/hooks/useToast'
+import api from '@/utils/axios'
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+
+export default function useTokenRefresh(options?: UseMutationOptions) {
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  const { triggerToast } = useToast()
+
+  return useMutation({
+    ...options,
+    mutationKey: ['token', 'refresh'],
+    mutationFn: async () => {
+      const response = await api.post(`/token/refresh`)
+      const newAccessToken = response.data.access_token
+      return newAccessToken
+    },
+    onError: () => {
+      // TODO: 로그인 여부 전역 상태 false로 설정
+      qc.removeQueries({ queryKey: ['users', 'me'] })
+      triggerToast('error', '로그인이 만료되었습니다. 다시 로그인 해주세요.')
+      navigate('/auth/login')
+    },
+  })
+}

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -1,16 +1,14 @@
-import useToast from '@/hooks/useToast'
+import { useLoginStore } from '@/store/useLoginStore'
 import api from '@/utils/axios'
 import {
   useMutation,
   useQueryClient,
   type UseMutationOptions,
 } from '@tanstack/react-query'
-import { useNavigate } from 'react-router'
 
 export default function useTokenRefresh(options?: UseMutationOptions) {
   const qc = useQueryClient()
-  const navigate = useNavigate()
-  const { triggerToast } = useToast()
+  const { setLoggedOut } = useLoginStore()
 
   return useMutation({
     ...options,
@@ -21,10 +19,8 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
       return newAccessToken
     },
     onError: () => {
-      // TODO: 로그인 여부 전역 상태 false로 설정
+      setLoggedOut()
       qc.removeQueries({ queryKey: ['users', 'me'] })
-      triggerToast('error', '로그인이 만료되었습니다. 다시 로그인 해주세요.')
-      navigate('/auth/login')
     },
   })
 }

--- a/src/hooks/api/auth/useUserInformation.ts
+++ b/src/hooks/api/auth/useUserInformation.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from '@/constants/api-constants'
+import { useLoginStore } from '@/store/useLoginStore'
 import type { UserInformation } from '@/types/api-response-types/auth-response-types'
 import api from '@/utils/axios'
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
@@ -6,6 +7,8 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 export default function useUserInformation(
   options?: UseQueryOptions<UserInformation>
 ) {
+  const { isLoggedIn } = useLoginStore()
+
   return useQuery<UserInformation>({
     ...options,
     queryKey: ['users', 'me'],
@@ -19,6 +22,6 @@ export default function useUserInformation(
         profileImageUrl: data.profile_image_url,
       }
     },
-    retry: false,
+    enabled: isLoggedIn,
   })
 }

--- a/src/hooks/api/useAxiosInterceptor.ts
+++ b/src/hooks/api/useAxiosInterceptor.ts
@@ -7,9 +7,14 @@ import { getAccessToken, isPublicEndpoint, setAccessToken } from '@/utils'
 import api from '@/utils/axios'
 import { useEffect } from 'react'
 import useTokenRefresh from '@/hooks/api/auth/useTokenRefresh'
+import { useLocation, useNavigate } from 'react-router'
+import { useToast } from '@/hooks'
 
 export default function useAxiosInterceptor() {
   const tokenRefresh = useTokenRefresh()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { triggerToast } = useToast()
 
   const requestHandler = async (config: InternalAxiosRequestConfig) => {
     const { url } = config
@@ -44,8 +49,11 @@ export default function useAxiosInterceptor() {
   const errorHandler = (error: AxiosError) => {
     const { config, response } = error
     const isTokenRefresh = config?.url?.includes('token/refresh')
-    if (response?.status === 401 && isTokenRefresh) {
-      window.location.href = '/auth/login'
+    const isMypageLocated = location.pathname.includes('my-page')
+
+    if (response?.status === 401 && isTokenRefresh && isMypageLocated) {
+      navigate('/auth/login')
+      triggerToast('error', '로그인이 만료되었습니다. 다시 로그인 해주세요.')
     }
 
     return Promise.reject(error)

--- a/src/hooks/api/useAxiosInterceptor.ts
+++ b/src/hooks/api/useAxiosInterceptor.ts
@@ -1,9 +1,5 @@
-import type {
-  AxiosError,
-  AxiosResponse,
-  InternalAxiosRequestConfig,
-} from 'axios'
-import { getAccessToken, isPublicEndpoint, setAccessToken } from '@/utils'
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { getAccessToken, isPublicEndpoint } from '@/utils'
 import api from '@/utils/axios'
 import { useEffect } from 'react'
 import useTokenRefresh from '@/hooks/api/auth/useTokenRefresh'
@@ -33,19 +29,6 @@ export default function useAxiosInterceptor() {
     return config
   }
 
-  const responseHandler = (response: AxiosResponse) => {
-    const { config, data } = response
-    const isLogin = config.url?.includes('auth/email/login')
-    const isTokenRefresh = config.url?.includes('token/refresh')
-    const accessToken = data?.access_token
-
-    if ((isLogin || isTokenRefresh) && accessToken) {
-      setAccessToken(accessToken)
-    }
-
-    return response
-  }
-
   const errorHandler = (error: AxiosError) => {
     const { config, response } = error
     const isTokenRefresh = config?.url?.includes('token/refresh')
@@ -62,7 +45,7 @@ export default function useAxiosInterceptor() {
   const requestInterceptor = api.interceptors.request.use(requestHandler)
 
   const responseInterceptor = api.interceptors.response.use(
-    (response) => responseHandler(response),
+    (response) => response,
     (error) => errorHandler(error)
   )
 

--- a/src/hooks/api/useAxiosInterceptor.ts
+++ b/src/hooks/api/useAxiosInterceptor.ts
@@ -1,0 +1,67 @@
+import type {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios'
+import { getAccessToken, isPublicEndpoint, setAccessToken } from '@/utils'
+import api from '@/utils/axios'
+import { useEffect } from 'react'
+import useTokenRefresh from '@/hooks/api/auth/useTokenRefresh'
+
+export default function useAxiosInterceptor() {
+  const tokenRefresh = useTokenRefresh()
+
+  const requestHandler = async (config: InternalAxiosRequestConfig) => {
+    const { url } = config
+
+    if (url && !isPublicEndpoint(url)) {
+      const accessToken = getAccessToken()
+
+      if (!accessToken) {
+        const newAccessToken = await tokenRefresh.mutateAsync()
+        config.headers.Authorization = `Bearer ${newAccessToken}`
+      } else {
+        config.headers.Authorization = `Bearer ${accessToken}`
+      }
+    }
+
+    return config
+  }
+
+  const responseHandler = (response: AxiosResponse) => {
+    const { config, data } = response
+    const isLogin = config.url?.includes('auth/email/login')
+    const isTokenRefresh = config.url?.includes('token/refresh')
+    const accessToken = data?.access_token
+
+    if ((isLogin || isTokenRefresh) && accessToken) {
+      setAccessToken(accessToken)
+    }
+
+    return response
+  }
+
+  const errorHandler = (error: AxiosError) => {
+    const { config, response } = error
+    const isTokenRefresh = config?.url?.includes('token/refresh')
+    if (response?.status === 401 && isTokenRefresh) {
+      window.location.href = '/auth/login'
+    }
+
+    return Promise.reject(error)
+  }
+
+  const requestInterceptor = api.interceptors.request.use(requestHandler)
+
+  const responseInterceptor = api.interceptors.response.use(
+    (response) => responseHandler(response),
+    (error) => errorHandler(error)
+  )
+
+  useEffect(() => {
+    return () => {
+      api.interceptors.request.eject(requestInterceptor)
+      api.interceptors.response.eject(responseInterceptor)
+    }
+  }, [requestInterceptor, responseInterceptor])
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -4,7 +4,7 @@ import type { Toast } from '@/types'
 const TIMEOUT = 3000
 
 function useToast() {
-  const { addToast, removeToast } = useToastStore()
+  const { addToast, removeToast } = useToastStore.getState()
 
   const triggerToast = (type: Toast['type'], content: Toast['content']) => {
     const newToast = { id: Date.now(), type: type, content: content }

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTimer } from './useTimer'
-import useToast from './useToast'
+import { useToast } from '@/hooks'
 
 const TIMER_DURATION_MS = 180000
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,8 +3,11 @@ import { BenefitCard } from '@/components/common/card/BenefitCard'
 import { CardTitle } from '@/components/common/card/Card'
 import LandingPageImage from '@/assets/images/LandingPageImage.jpg'
 import { BookOpen, Award, ArrowRight, UsersRound } from 'lucide-react'
+import { useLoginStore } from '@/store/useLoginStore'
 
 const LandingPage = () => {
+  const { isLoggedIn } = useLoginStore()
+
   return (
     <div className="mx-auto flex max-w-[1440px] flex-col">
       {/* 1번 섹션 */}
@@ -153,18 +156,20 @@ const LandingPage = () => {
             수백 개의 강의와 활발한 스터디 그룹이 여러분을 기다리고 있습니다.
           </div>
           <div className="flex gap-4">
-            {/* TODO: 전역상태로 로그인 상태받아 조건부 렌더링 추가 */}
-            {/* 비 로그인 시에는 무료로 시작하기만 존재하는 게 맞는 것 같음 */}
-            <Button variant="reverse" size="lg" className="bg-white">
-              무료로 시작하기
-            </Button>
-            {/* 로그인 시 아래 버튼으로 변경 */}
-            {/* <Button variant="reverse" size="lg" className="bg-white">
-              스터디 그룹 참여하기
-            </Button> */}
-            <Button size="lg" className="border-[2px] border-white">
-              스터디 그룹 만들기
-            </Button>
+            {isLoggedIn ? (
+              <>
+                <Button variant="reverse" size="lg" className="bg-white">
+                  스터디 그룹 참여하기
+                </Button>
+                <Button size="lg" className="border-[2px] border-white">
+                  스터디 그룹 만들기
+                </Button>
+              </>
+            ) : (
+              <Button variant="reverse" size="lg" className="bg-white">
+                무료로 시작하기
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/TestHub.tsx
+++ b/src/pages/TestHub.tsx
@@ -33,7 +33,7 @@ function TestHub() {
       </aside>
       <main className="w-full overflow-auto p-20">
         <Suspense fallback={<div>Loading...</div>}>
-          <Outlet />
+          <Outlet key={pathname} />
         </Suspense>
       </main>
     </main>

--- a/src/store/useLoginStore.ts
+++ b/src/store/useLoginStore.ts
@@ -1,0 +1,14 @@
+import { getAccessToken } from '@/utils'
+import { create } from 'zustand'
+
+interface LoginStore {
+  isLoggedIn: boolean
+  setLoggedIn: () => void
+  setLoggedOut: () => void
+}
+
+export const useLoginStore = create<LoginStore>((set) => ({
+  isLoggedIn: getAccessToken() ? true : false,
+  setLoggedIn: () => set(() => ({ isLoggedIn: true })),
+  setLoggedOut: () => set(() => ({ isLoggedIn: false })),
+}))

--- a/src/store/useLoginStore.ts
+++ b/src/store/useLoginStore.ts
@@ -3,12 +3,10 @@ import { create } from 'zustand'
 
 interface LoginStore {
   isLoggedIn: boolean
-  setLoggedIn: () => void
-  setLoggedOut: () => void
+  setIsLoggedIn: (value: boolean) => void
 }
 
 export const useLoginStore = create<LoginStore>((set) => ({
   isLoggedIn: getAccessToken() ? true : false,
-  setLoggedIn: () => set(() => ({ isLoggedIn: true })),
-  setLoggedOut: () => set(() => ({ isLoggedIn: false })),
+  setIsLoggedIn: (newValue) => set({ isLoggedIn: newValue }),
 }))

--- a/src/tests/LoginTest.tsx
+++ b/src/tests/LoginTest.tsx
@@ -4,6 +4,7 @@ import { Input, InputLabel } from '@/components/common/input'
 import { useUserInformation } from '@/hooks/api'
 import useLogin from '@/hooks/api/auth/useLogin'
 import useLogout from '@/hooks/api/auth/useLogout'
+import { useLoginStore } from '@/store/useLoginStore'
 import { formattedDateWithDots } from '@/utils/formatted-dates'
 import { useState } from 'react'
 
@@ -12,7 +13,8 @@ function UserInformationTest() {
   const [passwordValue, setPasswordValue] = useState('Qwer1234!!')
   const login = useLogin()
   const logout = useLogout()
-  const { data: user, isError: isUserInformationError } = useUserInformation()
+  const { data: user } = useUserInformation()
+  const { isLoggedIn } = useLoginStore()
 
   const handleLogin = () => {
     login.mutate({ email: emailValue, password: passwordValue })
@@ -25,7 +27,7 @@ function UserInformationTest() {
   return (
     <div className="flex flex-col items-center gap-10">
       <h3 className="text-center text-xl font-semibold">로그인 Test</h3>
-      {!isUserInformationError ? (
+      {isLoggedIn ? (
         <Button onClick={handleLogout}>로그아웃</Button>
       ) : (
         <div className="flex w-full flex-col items-center gap-6">

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -9,43 +9,4 @@ const api = axios.create({
   withCredentials: true,
 })
 
-api.interceptors.request.use((config) => {
-  const accessToken = localStorage.getItem('access-token')
-
-  if (accessToken) {
-    config.headers.Authorization = `Bearer ${accessToken}`
-  }
-
-  return config
-})
-
-api.interceptors.response.use(
-  (response) => {
-    const { config, data } = response
-    const isLogin = config.url?.includes('auth/email/login')
-    const accessToken = data?.access_token
-
-    if (isLogin && accessToken) {
-      localStorage.setItem('access-token', accessToken)
-    }
-
-    return response
-  },
-  async (error) => {
-    const { config } = error
-    const isTokenRefreshRequest = config.url?.includes('/token/refresh')
-
-    if (error.response?.status === 401 && !isTokenRefreshRequest) {
-      try {
-        await api.post(`${API_BASE_URL}/token/refresh`)
-        return api(error.config)
-      } catch {
-        const pathname = window.location.pathname
-        if (pathname.includes('my-page')) window.location.href = '/auth/login'
-      }
-    }
-    return Promise.reject(error)
-  }
-)
-
 export default api

--- a/src/utils/check-endpoints.ts
+++ b/src/utils/check-endpoints.ts
@@ -1,0 +1,5 @@
+import { PUBLIC_ENDPOINTS } from '@/constants/api-endpoints'
+
+export const isPublicEndpoint = (url: string) => {
+  return PUBLIC_ENDPOINTS.some((endpoint) => url.includes(endpoint))
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,5 +6,21 @@ import {
   formattedCloseAt,
   formattedEndDate,
 } from '@/utils/formatted-dates'
+import { isPublicEndpoint } from '@/utils/check-endpoints'
+import {
+  clearAccessToken,
+  getAccessToken,
+  setAccessToken,
+} from '@/utils/manage-token'
 
-export { cn, testPages, formattedAppliedAt, formattedCloseAt, formattedEndDate }
+export {
+  cn,
+  testPages,
+  formattedAppliedAt,
+  formattedCloseAt,
+  formattedEndDate,
+  isPublicEndpoint,
+  clearAccessToken,
+  getAccessToken,
+  setAccessToken,
+}

--- a/src/utils/manage-token.ts
+++ b/src/utils/manage-token.ts
@@ -1,0 +1,11 @@
+export function getAccessToken() {
+  return localStorage.getItem('access-token')
+}
+
+export function setAccessToken(token: string) {
+  localStorage.setItem('access-token', token)
+}
+
+export function clearAccessToken() {
+  localStorage.removeItem('access-token')
+}


### PR DESCRIPTION
## 🚀 PR 요약

변경된 인증 & 인가 처리 방식에 맞춰 기존의 **axois interceptor**, **로그인 & 로그아웃 msw**, **로그인 test 페이지**를 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useAxiosInterceptor` 훅으로 **axois interceptor** 관리 _(참고자료: [Issue #199](https://github.com/OZ-Coding-School/oz_externship_fe_02_team4/issues/199) 참고할만한 자료에 기록)_
- 로그인 여부를 전역 상태로 관리하기 위해 `useLoginStore` 추가  
  - `isLoggedIn`: 현재 로컬 스토리지에 액세스 토큰이 존재하는 지 하지 않는 지 확인 후 true 또는  false를 초기값으로 가짐
  - `setIsLoggedIn`: 매개변수로 true 또는 false를 넣어 로그인 여부 상태를 변경
- `useUserInformation`에서 `enabled` 옵션 삭제 예정이었으나, 수정된 로직에 따라 `enabled: isLoggedIn` 유지
- `useLogin`, `useLogout`, `useTokenRefresh` 등의 훅에서 상황에 맞게 액세스 토큰을 저장 또는 삭제하고 `isLoggedIn` 상태를 바꾸도록 수정

### 참고 사항

- **axois interceptor** 관리 방식 변경
  - 기존에는 axios 인스턴스에 직접 interceptor를 등록하여 관리했습니다.
  - 그러나 토큰 재발급 과정에서 React Hook을 활용해야 하는 요구사항이 생기면서 기존 방식으로는 대응할 수 없었습니다.
  - 이에 따라 **interceptor**를 별도의 React Hook(`useAxiosInterceptor`)으로 분리하고, **App.tsx**에서 적용하는 구조로 수정했습니다.

- 로그인 여부 관리 방식 개선
  - **App.tsx**가 최초로 렌더링될 때 `getAccessToken` 함수를 통해 로컬 스토리지에 액세스 토큰이 존재하는지 확인하고, 만약 없다면 `/token/refresh` 요청을 무조건 한 번 실행하도록 변경했습니다.
  - 이를 통해 새로고침 이후에도 리프레시 토큰이 유효하다면 새로운 액세스 토큰을 발급받아 로그인 상태를 안정적으로 유지할 수 있습니다.
  - 관련 트러블슈팅: [인증 인가 처리 방식 notion](https://www.notion.so/276caf5650aa806796b0d49c5163e6ef?source=copy_link)
 
### 스크린 샷

**로그인 -> 사용자 정보 조회 -> 로그아웃 test**
(중간에 새로고침해도 에러 발생 X)
![StudyHub-Chrome2025-09-2117-51-05-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/91b3b48a-d960-4cf9-ad79-fed0b7cf321f)

**액세스 토큰이 만료된 상태에서 새로고침 시 액세스 토큰을 재발급하여 로그인 상태 유지**
![StudyHub-Chrome2025-09-2117-55-31-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/fc36a8fe-89fb-4702-a151-1b1efdedd404)

## 🔗 연관된 이슈

> closes #199
