### PR TITLE
Design: Auth 관련 component & page 스타일 수정

### DIFF
--- a/src/components/auth/common/AuthContainer.tsx
+++ b/src/components/auth/common/AuthContainer.tsx
@@ -9,7 +9,7 @@ export function AuthContainer({
   return (
     <section
       className={cn(
-        'w-112 rounded-lg bg-white px-6 py-12 shadow-md',
+        'w-112 rounded-lg bg-white px-8 py-12 shadow-md',
         className
       )}
       {...props}

--- a/src/components/auth/find-email/FindEmailFirstStep.tsx
+++ b/src/components/auth/find-email/FindEmailFirstStep.tsx
@@ -5,6 +5,7 @@ import {
   AuthIcon,
 } from '@/components/auth/common'
 import { Input, InputErrorMessage } from '@/components/common/input'
+import { InputFieldColStyle, InputGroupStyle } from '@/constants/auth-variants'
 import {
   FindEmailStep1Schema,
   type FindEmailStep1Type,
@@ -46,14 +47,14 @@ function FindEmailFirstStep({
           가입 시 입력한 이름과 휴대폰 번호를 입력해주세요
         </AuthDescription>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
-        <div className="flex flex-col gap-2">
+      <form onSubmit={handleSubmit(onSubmit)} className={InputGroupStyle}>
+        <div className={InputFieldColStyle}>
           <Input placeholder="이름" {...register('name')} />
           {errors.name && (
             <InputErrorMessage>{`${errors.name.message}`}</InputErrorMessage>
           )}
         </div>
-        <div className="flex flex-col gap-2">
+        <div className={InputFieldColStyle}>
           <Input placeholder="휴대전화 번호" {...register('phoneNumber')} />
           {errors.phoneNumber && (
             <InputErrorMessage>{`${errors.phoneNumber.message}`}</InputErrorMessage>

--- a/src/components/auth/find-email/FindEmailSecondStep.tsx
+++ b/src/components/auth/find-email/FindEmailSecondStep.tsx
@@ -7,6 +7,11 @@ import {
   AuthVerifyButton,
 } from '@/components/auth/common'
 import { Input, InputErrorMessage } from '@/components/common/input'
+import {
+  InputFieldColStyle,
+  InputFieldRowStyle,
+  InputGroupStyle,
+} from '@/constants/auth-variants'
 import { useVerificationCode } from '@/hooks'
 import {
   FindEmailStep2Schema,
@@ -60,9 +65,9 @@ function FindEmailSecondStep({
           {phoneNumber}로 인증코드를 발송했습니다.
         </AuthDescription>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2">
+      <form onSubmit={handleSubmit(onSubmit)} className={InputGroupStyle}>
+        <div className={InputFieldColStyle}>
+          <div className={InputFieldRowStyle}>
             <Input
               {...register('code')}
               placeholder="인증코드 6자리를 입력해주세요"

--- a/src/components/auth/find-password/FindPasswordFirstStep.tsx
+++ b/src/components/auth/find-password/FindPasswordFirstStep.tsx
@@ -5,6 +5,7 @@ import {
   AuthIcon,
 } from '@/components/auth/common'
 import { Input, InputErrorMessage } from '@/components/common/input'
+import { InputFieldColStyle, InputGroupStyle } from '@/constants/auth-variants'
 import {
   FindPasswordStep1Schema,
   type FindPasswordStep1Type,
@@ -46,8 +47,8 @@ function FindPasswordFirstStep({
           가입하신 이메일을 입력하면 인증코드를 보내드립니다
         </AuthDescription>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
-        <div className="flex flex-col gap-2">
+      <form onSubmit={handleSubmit(onSubmit)} className={InputGroupStyle}>
+        <div className={InputFieldColStyle}>
           <Input placeholder="이메일" {...register('email')} />
           {errors.email && (
             <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>

--- a/src/components/auth/find-password/FindPasswordSecondStep.tsx
+++ b/src/components/auth/find-password/FindPasswordSecondStep.tsx
@@ -7,6 +7,11 @@ import {
   AuthIcon,
 } from '@/components/auth/common'
 import { Input, InputErrorMessage } from '@/components/common/input'
+import {
+  InputFieldColStyle,
+  InputFieldRowStyle,
+  InputGroupStyle,
+} from '@/constants/auth-variants'
 import { useVerificationCode } from '@/hooks'
 import {
   FindPasswordStep2Schema,
@@ -58,9 +63,9 @@ function FindPasswordSecondStep({
         </AuthTitle>
         <AuthDescription>{email}로 인증코드를 발송했습니다.</AuthDescription>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2">
+      <form onSubmit={handleSubmit(onSubmit)} className={InputGroupStyle}>
+        <div className={InputFieldColStyle}>
+          <div className={InputFieldRowStyle}>
             <Input
               {...register('code')}
               placeholder="인증코드 6자리를 입력해주세요"

--- a/src/components/auth/find-password/FindPasswordThirdStep.tsx
+++ b/src/components/auth/find-password/FindPasswordThirdStep.tsx
@@ -5,6 +5,7 @@ import {
   AuthIcon,
 } from '@/components/auth/common'
 import { InputErrorMessage, PasswordInput } from '@/components/common/input'
+import { InputFieldColStyle, InputGroupStyle } from '@/constants/auth-variants'
 import {
   FindPasswordStep3Schema,
   type FindPasswordStep3Type,
@@ -47,14 +48,14 @@ function FindPasswordThirdStep({
         </AuthTitle>
         <AuthDescription>새로운 비밀번호를 입력해주세요</AuthDescription>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
-        <div className="flex flex-col gap-2">
+      <form onSubmit={handleSubmit(onSubmit)} className={InputGroupStyle}>
+        <div className={InputFieldColStyle}>
           <PasswordInput placeholder="새 비밀번호" {...register('password')} />
           {errors.password && (
             <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
           )}
         </div>
-        <div className="flex flex-col gap-2">
+        <div className={InputFieldColStyle}>
           <PasswordInput
             placeholder="비밀번호 확인"
             {...register('confirmPassword')}

--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router'
 
 export default function AuthLayout() {
   return (
-    <div className="flex items-center justify-center py-0 sm:py-30">
+    <div className="flex items-center justify-center bg-gray-50 py-0 sm:py-30">
       <Outlet />
     </div>
   )

--- a/src/constants/auth-variants.ts
+++ b/src/constants/auth-variants.ts
@@ -1,0 +1,5 @@
+export const InputFieldRowStyle = 'flex gap-2'
+
+export const InputFieldColStyle = 'flex flex-col gap-2'
+
+export const InputGroupStyle = 'flex flex-col gap-4'

--- a/src/pages/auth/FindEmail.tsx
+++ b/src/pages/auth/FindEmail.tsx
@@ -8,6 +8,8 @@ import { useState } from 'react'
 import FindEmailFirstStep from '@/components/auth/find-email/FindEmailFirstStep'
 import FindEmailSecondStep from '@/components/auth/find-email/FindEmailSecondStep'
 import FindEmailThirdStep from '@/components/auth/find-email/FindEmailThirdStep'
+import { InputFieldColStyle } from '@/constants/auth-variants'
+import { cn } from '@/utils'
 
 const FIND_EMAIL_STEP_LIST = ['정보입력', '휴대폰인증', '결과확인']
 
@@ -21,7 +23,7 @@ function FindEmail() {
 
   return (
     <AuthContainer className="flex flex-col gap-10">
-      <div className="flex flex-col items-center gap-1">
+      <div className={cn(InputFieldColStyle, 'text-center')}>
         <AuthTitle>이메일 찾기</AuthTitle>
         <AuthDescription>
           가입 시 입력한 정보로 이메일을 찾을 수 있습니다

--- a/src/pages/auth/FindPassword.tsx
+++ b/src/pages/auth/FindPassword.tsx
@@ -10,6 +10,8 @@ import FindPasswordSecondStep from '@/components/auth/find-password/FindPassword
 import FindPasswordThirdStep from '@/components/auth/find-password/FindPasswordThirdStep'
 import { useNavigate } from 'react-router'
 import { useToast } from '@/hooks'
+import { InputFieldColStyle } from '@/constants/auth-variants'
+import { cn } from '@/utils'
 
 const FIND_EMAIL_STEP_LIST = ['이메일입력', '이메일인증', '비밀번호재설정']
 
@@ -25,7 +27,7 @@ function FindPassword() {
 
   return (
     <AuthContainer className="flex flex-col gap-10">
-      <div className="flex flex-col items-center gap-1">
+      <div className={cn(InputFieldColStyle, 'text-center')}>
         <AuthTitle>비밀번호 찾기</AuthTitle>
         <AuthDescription>
           가입한 이메일로 비밀번호를 재설정할 수 있습니다

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -15,8 +15,11 @@ import {
   type LoginSchemaType,
 } from '@/schemas/form-schema/auth-schema'
 import { useLogin } from '@/hooks/api'
-
-const flexStyle = 'flex flex-col gap-4'
+import {
+  InputFieldColStyle,
+  InputFieldRowStyle,
+  InputGroupStyle,
+} from '@/constants/auth-variants'
 
 function Login() {
   const {
@@ -36,7 +39,7 @@ function Login() {
 
   return (
     <AuthContainer className="flex flex-col gap-10">
-      <div className={flexStyle}>
+      <div className={InputGroupStyle}>
         <AuthLogo />
         <AuthTitle>로그인</AuthTitle>
         <div className="flex justify-center gap-1">
@@ -45,13 +48,13 @@ function Login() {
         </div>
       </div>
 
-      <div className={flexStyle}>
+      <div className={InputGroupStyle}>
         <AuthSocialLoginButton socialType="kakao" />
         <AuthSocialLoginButton socialType="naver" />
       </div>
 
-      <form className={flexStyle} onSubmit={handleSubmit(onSubmit)}>
-        <div className="flex flex-col gap-2">
+      <form className={InputGroupStyle} onSubmit={handleSubmit(onSubmit)}>
+        <div className={InputFieldColStyle}>
           <Input
             {...register('email')}
             type="email"
@@ -61,7 +64,7 @@ function Login() {
             <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
           )}
         </div>
-        <div className="flex flex-col gap-2">
+        <div className={InputFieldColStyle}>
           <Input
             {...register('password')}
             type="password"
@@ -71,7 +74,7 @@ function Login() {
             <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
           )}
         </div>
-        <div className="flex gap-2">
+        <div className={InputFieldRowStyle}>
           <AuthLink to="/auth/find-email">아이디 찾기</AuthLink>
           <span className="text-primary-600">|</span>
           <AuthLink to="/auth/find-password">비밀번호 찾기</AuthLink>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -2,7 +2,6 @@ import {
   AuthContainer,
   AuthDescription,
   AuthLink,
-  AuthLogo,
   AuthSocialLoginButton,
   AuthSubmitButton,
   AuthTitle,
@@ -39,8 +38,7 @@ function Login() {
 
   return (
     <AuthContainer className="flex flex-col gap-10">
-      <div className={InputGroupStyle}>
-        <AuthLogo />
+      <div className={InputFieldColStyle}>
         <AuthTitle>로그인</AuthTitle>
         <div className="flex justify-center gap-1">
           <AuthDescription>아직 계정이 없으신가요?</AuthDescription>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -6,7 +6,11 @@ import {
   AuthSubmitButton,
   AuthTitle,
 } from '@/components/auth/common'
-import { Input, InputErrorMessage } from '@/components/common/input'
+import {
+  Input,
+  InputErrorMessage,
+  PasswordInput,
+} from '@/components/common/input'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -63,9 +67,8 @@ function Login() {
           )}
         </div>
         <div className={InputFieldColStyle}>
-          <Input
+          <PasswordInput
             {...register('password')}
-            type="password"
             placeholder="비밀번호 (8~15자의 영문 대소문자, 숫자, 특수문자 포함)"
           />
           {errors.password && (

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/schemas/form-schema/auth-schema'
 import { useLogin } from '@/hooks/api'
 
-const flexStyle = 'flex flex-col gap-3'
+const flexStyle = 'flex flex-col gap-4'
 
 function Login() {
   const {
@@ -51,23 +51,26 @@ function Login() {
       </div>
 
       <form className={flexStyle} onSubmit={handleSubmit(onSubmit)}>
-        <Input
-          {...register('email')}
-          type="email"
-          placeholder="아이디 (example@gmail.com)"
-        />
-        {errors.email && (
-          <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
-        )}
-        <Input
-          {...register('password')}
-          type="password"
-          placeholder="비밀번호 (8~15자의 영문 대소문자, 숫자, 특수문자 포함)"
-        />
-        {errors.password && (
-          <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
-        )}
-
+        <div className="flex flex-col gap-2">
+          <Input
+            {...register('email')}
+            type="email"
+            placeholder="아이디 (example@gmail.com)"
+          />
+          {errors.email && (
+            <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <Input
+            {...register('password')}
+            type="password"
+            placeholder="비밀번호 (8~15자의 영문 대소문자, 숫자, 특수문자 포함)"
+          />
+          {errors.password && (
+            <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
+          )}
+        </div>
         <div className="flex gap-2">
           <AuthLink to="/auth/find-email">아이디 찾기</AuthLink>
           <span className="text-primary-600">|</span>

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -15,6 +15,10 @@ import {
   InputLabel,
   PasswordInput,
 } from '@/components/common/input'
+import {
+  InputFieldColStyle,
+  InputFieldRowStyle,
+} from '@/constants/auth-variants'
 import { useToast, useVerificationCode } from '@/hooks'
 import {
   authSchema,
@@ -25,9 +29,6 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
-
-const flexRowStyle = 'flex gap-2'
-const flexColStyle = 'flex flex-col gap-2'
 
 function Signup() {
   const [isDuplicateChecked, setIsDuplicateChecked] = useState(false)
@@ -73,7 +74,7 @@ function Signup() {
 
   return (
     <AuthContainer className="flex flex-col gap-10">
-      <div className={flexColStyle}>
+      <div className={InputFieldColStyle}>
         <AuthLogo />
         <AuthTitle>회원가입</AuthTitle>
         <div className="flex justify-center gap-1">
@@ -83,7 +84,7 @@ function Signup() {
       </div>
       <form className="flex flex-col gap-10" onSubmit={handleSubmit(onSubmit)}>
         {/* 이름 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <InputLabel isRequired>이름</InputLabel>
           <Input {...register('name')} placeholder="이름을 입력해주세요" />
           {errors.name && (
@@ -91,9 +92,9 @@ function Signup() {
           )}
         </div>
         {/* 닉네임 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <InputLabel isRequired>닉네임</InputLabel>
-          <div className={flexRowStyle}>
+          <div className={InputFieldRowStyle}>
             <Input
               {...register('nickname')}
               placeholder="닉네임을 입력해주세요"
@@ -110,7 +111,7 @@ function Signup() {
           )}
         </div>
         {/* 생년월일 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <InputLabel isRequired>생년월일</InputLabel>
           <Input
             {...register('birthday')}
@@ -121,9 +122,9 @@ function Signup() {
           )}
         </div>
         {/* 성별 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <InputLabel isRequired>성별</InputLabel>
-          <div className={flexRowStyle}>
+          <div className={InputFieldRowStyle}>
             <label htmlFor="gender-male">
               <AuthBadge isSelected={watch('gender') === 'male'}>남</AuthBadge>
             </label>
@@ -152,12 +153,12 @@ function Signup() {
           )}
         </div>
         {/* 이메일 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <div className="flex gap-3">
             <InputLabel isRequired>이메일</InputLabel>
             <InputDescription>로그인 시 아이디로 사용합니다.</InputDescription>
           </div>
-          <div className={flexRowStyle}>
+          <div className={InputFieldRowStyle}>
             <Input {...register('email')} placeholder="이메일을 입력해주세요" />
             <AuthVerifyButton
               className={cn(timer.email.isCounting && 'w-44 p-0')}
@@ -172,7 +173,7 @@ function Signup() {
           {errors.email && (
             <InputErrorMessage>{`${errors.email.message}`}</InputErrorMessage>
           )}
-          <div className={flexRowStyle}>
+          <div className={InputFieldRowStyle}>
             <Input
               {...register('verificationCode.email')}
               placeholder="인증코드 6자리를 입력해주세요"
@@ -189,7 +190,7 @@ function Signup() {
           )}
         </div>
         {/* 휴대전화 */}
-        <div className={flexColStyle}>
+        <div className={InputFieldColStyle}>
           <InputLabel isRequired>휴대전화</InputLabel>
           <div className="flex gap-3">
             <Input
@@ -209,7 +210,7 @@ function Signup() {
           {errors.phoneNumber && (
             <InputErrorMessage>{`${errors.phoneNumber.message}`}</InputErrorMessage>
           )}
-          <div className={flexRowStyle}>
+          <div className={InputFieldRowStyle}>
             <Input
               {...register('verificationCode.phoneNumber')}
               placeholder="인증코드 6자리를 입력해주세요"
@@ -226,14 +227,14 @@ function Signup() {
           )}
         </div>
         {/* 비밀번호 */}
-        <div className={flexColStyle}>
-          <div className={flexRowStyle}>
+        <div className={InputFieldColStyle}>
+          <div className={InputFieldRowStyle}>
             <InputLabel isRequired>비밀번호</InputLabel>
             <InputDescription>
               8~15자의 영문 대소문자, 숫자, 특수문자 포함
             </InputDescription>
           </div>
-          <div className={flexColStyle}>
+          <div className={InputFieldColStyle}>
             <PasswordInput
               {...register('password')}
               placeholder="비밀번호를 입력해주세요"
@@ -242,7 +243,7 @@ function Signup() {
               <InputErrorMessage>{`${errors.password.message}`}</InputErrorMessage>
             )}
           </div>
-          <div className={flexColStyle}>
+          <div className={InputFieldColStyle}>
             <PasswordInput
               {...register('confirmPassword')}
               placeholder="비밀번호를 다시 입력해주세요"

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -3,7 +3,6 @@ import {
   AuthContainer,
   AuthDescription,
   AuthLink,
-  AuthLogo,
   AuthSubmitButton,
   AuthTitle,
   AuthVerifyButton,
@@ -75,7 +74,6 @@ function Signup() {
   return (
     <AuthContainer className="flex flex-col gap-10">
       <div className={InputFieldColStyle}>
-        <AuthLogo />
         <AuthTitle>회원가입</AuthTitle>
         <div className="flex justify-center gap-1">
           <AuthDescription>이미 계정이 있으신가요?</AuthDescription>

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -26,8 +26,8 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
-const flexRowStyle = 'flex gap-3'
-const flexColStyle = 'flex flex-col gap-3'
+const flexRowStyle = 'flex gap-2'
+const flexColStyle = 'flex flex-col gap-2'
 
 function Signup() {
   const [isDuplicateChecked, setIsDuplicateChecked] = useState(false)


### PR DESCRIPTION
## 🚀 PR 요약

**Auth** 관련 작업 중 발견한 컴포넌트와 페이지의 전반적인 수정 사항을 적용했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **AuthContainer** `padding` 수정
- **AuthLayout** 배경색 추가
- **Auth** 페이지들에 적용할 `flex` 스타일 상수 `variants` 추가 및 적용
- **Login**, **Signup** 페이지 내 로고 삭제
- **Login** 페이지에 비밀번호 전용 `Input` 적용

### 스크린 샷

자잘하게 수정한 거라 이전과 큰 차이는 없는데, 입력 필드와 에러 메시지와의 간격 스타일이 통일되어서 그 부분 위주로 캡쳐했습니다.

<img width="1905" height="1251" alt="localhost_5173_auth_login (2)" src="https://github.com/user-attachments/assets/de54bb70-16c3-449a-b430-0139294b3def" />

<img width="1905" height="2077" alt="localhost_5173_auth_login (4)" src="https://github.com/user-attachments/assets/d619a51e-dabd-4e13-b290-ce5cc1b4c2e6" />

## 🔗 연관된 이슈

> closes #213
