### PR TITLE
Feature: 회원 복구 모달 UI

### DIFF
--- a/src/components/auth/user-recover-modal/UserRecoverCompleteModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverCompleteModal.tsx
@@ -1,0 +1,31 @@
+import {
+  Modal,
+  ModalContent,
+  ModalMain,
+  type ModalContextValue,
+} from '@/components/common/Modal'
+import { RotateCwIcon } from 'lucide-react'
+
+interface UserRecoverCompleteModalProps {
+  userRecoverCompleteModalControl: ModalContextValue
+}
+
+export default function UserRecoverCompleteModal({
+  userRecoverCompleteModalControl,
+}: UserRecoverCompleteModalProps) {
+  return (
+    <Modal externalModalControl={userRecoverCompleteModalControl}>
+      <ModalContent className="flex w-[90%] max-w-sm flex-col items-center">
+        <ModalMain className="flex flex-col items-center gap-2">
+          <div className="bg-success-500 flex size-7 items-center justify-center rounded-full text-gray-100">
+            <RotateCwIcon className="h-5" />
+          </div>
+          <h1 className="text-center text-xl font-bold text-gray-900">
+            계정 복구 완료!
+          </h1>
+          <p className="text-center text-gray-600">지금 바로 로그인해 보세요</p>
+        </ModalMain>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
@@ -1,0 +1,75 @@
+import { AuthVerifyButton } from '@/components/auth/common'
+import Button from '@/components/common/Button'
+import { InputLabel, Input } from '@/components/common/input'
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalMain,
+  type ModalContextValue,
+} from '@/components/common/Modal'
+import { RotateCwIcon } from 'lucide-react'
+
+interface UserRecoverFormModalProps {
+  userRecoverFormModalControl: ModalContextValue
+  userRecoverCompleteModalOpen: () => void
+}
+
+export default function UserRecoverFormModal({
+  userRecoverFormModalControl,
+  userRecoverCompleteModalOpen,
+}: UserRecoverFormModalProps) {
+  return (
+    <Modal externalModalControl={userRecoverFormModalControl}>
+      <ModalContent className="flex w-[90%] max-w-lg flex-col items-center">
+        <ModalHeader className="w-full border-none" />
+        <ModalMain className="flex w-full flex-col gap-5">
+          <div className="flex flex-col items-center gap-2">
+            <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
+              <RotateCwIcon className="h-5" />
+            </div>
+            <h1 className="text-center text-xl font-bold text-gray-900">
+              계정 다시 사용하기
+            </h1>
+            <p className="text-center text-gray-600">
+              입력하신 이메일로 인증번호를 보내드릴게요.
+            </p>
+          </div>
+          <form className="flex w-full flex-col items-start gap-5">
+            <InputLabel>
+              이메일 <span className="text-danger-500">*</span>
+            </InputLabel>
+            <div className="flex w-full gap-2">
+              <Input
+                placeholder="가입한 이메일을 입력해주세요."
+                className="flex-1"
+              />
+              <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+            </div>
+            <div className="flex w-full gap-2">
+              <Input
+                placeholder="인증번호를 입력해주세요."
+                className="flex-1"
+              />
+              <AuthVerifyButton>인증코드확인</AuthVerifyButton>
+            </div>
+          </form>
+        </ModalMain>
+        <ModalFooter className="flex w-full justify-center border-none">
+          <ModalClose className="flex w-full justify-center">
+            <Button
+              className="w-[90%] max-w-sm"
+              onClick={() => {
+                userRecoverCompleteModalOpen()
+              }}
+            >
+              확인
+            </Button>
+          </ModalClose>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
@@ -38,9 +38,7 @@ export default function UserRecoverFormModal({
             </p>
           </div>
           <form className="flex w-full flex-col items-start gap-5">
-            <InputLabel>
-              이메일 <span className="text-danger-500">*</span>
-            </InputLabel>
+            <InputLabel isRequired>이메일</InputLabel>
             <div className="flex w-full gap-2">
               <Input
                 placeholder="가입한 이메일을 입력해주세요."

--- a/src/components/auth/user-recover-modal/UserRecoverModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverModal.tsx
@@ -1,0 +1,71 @@
+import {
+  UserRecoverCompleteModal,
+  UserRecoverFormModal,
+  UserRecoverNoticeModal,
+} from '@/components/auth/user-recover-modal'
+import type { ModalContextValue } from '@/components/common/Modal'
+
+import { useState } from 'react'
+
+interface UserRecoverModalProps {
+  userRecoverModalControl: ModalContextValue
+}
+
+/**
+ * 회원 복구 모달
+ * 사용하기 위해서는 ModalContextValue 값을 가지는 객체를 한 개 만든 후 prop으로 전달
+ * UserRecoverModalTest 페이지 참고
+ */
+export default function UserRecoverModal({
+  userRecoverModalControl,
+}: UserRecoverModalProps) {
+  const [isUserRecoverFormModalOpen, setIsUserRecoverFormModalOpen] =
+    useState(false)
+
+  const userRecoverFormModalControl: ModalContextValue = {
+    isOpen: isUserRecoverFormModalOpen,
+    open: () => {
+      setIsUserRecoverFormModalOpen(true)
+    },
+    close: () => {
+      setIsUserRecoverFormModalOpen(false)
+    },
+    toggle: () => {
+      setIsUserRecoverFormModalOpen((prev) => !prev)
+    },
+  }
+
+  const [isUserRecoverCompleteModalOpen, setIsUserRecoverCompleteModalOpen] =
+    useState(false)
+
+  const userRecoverCompleteModalControl: ModalContextValue = {
+    isOpen: isUserRecoverCompleteModalOpen,
+    open: () => {
+      setIsUserRecoverCompleteModalOpen(true)
+    },
+    close: () => {
+      setIsUserRecoverCompleteModalOpen(false)
+    },
+    toggle: () => {
+      setIsUserRecoverCompleteModalOpen((prev) => !prev)
+    },
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <UserRecoverNoticeModal
+        userRecoverNoticeModalControl={userRecoverModalControl}
+        userRecoverFormOpen={userRecoverFormModalControl.open}
+      />
+
+      <UserRecoverFormModal
+        userRecoverFormModalControl={userRecoverFormModalControl}
+        userRecoverCompleteModalOpen={userRecoverCompleteModalControl.open}
+      />
+
+      <UserRecoverCompleteModal
+        userRecoverCompleteModalControl={userRecoverCompleteModalControl}
+      />
+    </div>
+  )
+}

--- a/src/components/auth/user-recover-modal/UserRecoverNoticeModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverNoticeModal.tsx
@@ -1,0 +1,57 @@
+import Button from '@/components/common/Button'
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalMain,
+  type ModalContextValue,
+} from '@/components/common/Modal'
+import { MehIcon } from 'lucide-react'
+
+interface UserRecoverNoticeModalProps {
+  userRecoverNoticeModalControl: ModalContextValue
+  userRecoverFormOpen: () => void
+}
+
+export default function UserRecoverNoticeModal({
+  userRecoverNoticeModalControl,
+  userRecoverFormOpen,
+}: UserRecoverNoticeModalProps) {
+  return (
+    <Modal externalModalControl={userRecoverNoticeModalControl}>
+      <ModalContent className="w-[90%] max-w-lg">
+        <ModalHeader className="border-none" />
+        <ModalMain className="flex flex-col items-center gap-5">
+          <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
+            <MehIcon className="h-5" />
+          </div>
+          <h1 className="text-center text-xl font-bold text-gray-900">
+            해당 계정은 탈퇴된 상태예요
+          </h1>
+          <div>
+            <p className="text-center text-gray-600">
+              2025년 9월 20일 이후, 계정 정보는 완전히 삭제돼요.
+            </p>
+            <p className="text-center text-gray-600">
+              계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
+            </p>
+          </div>
+          <ModalFooter className="flex w-full justify-center border-none">
+            <ModalClose className="flex w-full justify-center">
+              <Button
+                onClick={() => {
+                  userRecoverFormOpen()
+                }}
+                className="w-[90%] max-w-sm"
+              >
+                계정 다시 사용하기
+              </Button>
+            </ModalClose>
+          </ModalFooter>
+        </ModalMain>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/auth/user-recover-modal/index.ts
+++ b/src/components/auth/user-recover-modal/index.ts
@@ -1,0 +1,11 @@
+import UserRecoverModal from '@/components/auth/user-recover-modal/UserRecoverModal'
+import UserRecoverCompleteModal from '@/components/auth/user-recover-modal/UserRecoverCompleteModal'
+import UserRecoverFormModal from '@/components/auth/user-recover-modal/UserRecoverFormModal'
+import UserRecoverNoticeModal from '@/components/auth/user-recover-modal/UserRecoverNoticeModal'
+
+export {
+  UserRecoverModal,
+  UserRecoverCompleteModal,
+  UserRecoverFormModal,
+  UserRecoverNoticeModal,
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -326,4 +326,5 @@ export {
   ModalDescription,
   ModalMain,
   useModalContext,
+  type ModalContextValue,
 }

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -3,14 +3,33 @@ import { AuthVerifyButton } from '@/components/auth/common'
 import { Input, InputLabel } from '@/components/common/input'
 import {
   Modal,
+  ModalClose,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalMain,
   ModalTrigger,
+  type ModalContextValue,
 } from '@/components/common/Modal'
 import { MehIcon, RotateCwIcon } from 'lucide-react'
+import { useState } from 'react'
 export default function UserRecoverModalTest() {
+  const [isUserRecoverFormModalOpen, setIsUserRecoverFormModalOpen] =
+    useState(false)
+
+  const userRecoverFormModalControl: ModalContextValue = {
+    isOpen: isUserRecoverFormModalOpen,
+    open: () => {
+      setIsUserRecoverFormModalOpen(true)
+    },
+    close: () => {
+      setIsUserRecoverFormModalOpen(false)
+    },
+    toggle: () => {
+      setIsUserRecoverFormModalOpen((prev) => !prev)
+    },
+  }
+
   return (
     <div className="flex flex-col gap-2">
       <Modal>
@@ -35,13 +54,22 @@ export default function UserRecoverModalTest() {
               </p>
             </div>
             <ModalFooter className="flex w-full justify-center border-none">
-              <Button className="w-[90%] max-w-sm">계정 다시 사용하기</Button>
+              <ModalClose className="flex w-full justify-center">
+                <Button
+                  onClick={() => {
+                    userRecoverFormModalControl.open()
+                  }}
+                  className="w-[90%] max-w-sm"
+                >
+                  계정 다시 사용하기
+                </Button>
+              </ModalClose>
             </ModalFooter>
           </ModalMain>
         </ModalContent>
       </Modal>
 
-      <Modal>
+      <Modal externalModalControl={userRecoverFormModalControl}>
         <ModalTrigger>
           <Button>계정 복구 폼 모달</Button>
         </ModalTrigger>

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -103,7 +103,7 @@ export default function UserRecoverModalTest() {
                   placeholder="인증번호를 입력해주세요."
                   className="flex-1"
                 />
-                <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+                <AuthVerifyButton>인증코드확인</AuthVerifyButton>
               </div>
             </form>
           </ModalMain>

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components'
-import { AuthVerifyButton } from '@/components/auth'
+import { AuthVerifyButton } from '@/components/auth/common'
 import { Input, InputLabel } from '@/components/common/input'
 import {
   Modal,
@@ -17,7 +17,7 @@ export default function UserRecoverModalTest() {
         <ModalTrigger>
           <Button>탈퇴 안내 모달</Button>
         </ModalTrigger>
-        <ModalContent className="w-[90%]">
+        <ModalContent className="w-[90%] max-w-lg">
           <ModalHeader className="border-none" />
           <ModalMain className="flex flex-col items-center gap-5">
             <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@/components'
+import { AuthVerifyButton } from '@/components/auth'
+import { Input, InputLabel } from '@/components/common/input'
 import {
   Modal,
   ModalContent,
@@ -7,13 +9,13 @@ import {
   ModalMain,
   ModalTrigger,
 } from '@/components/common/Modal'
-import { MehIcon } from 'lucide-react'
+import { MehIcon, RotateCwIcon } from 'lucide-react'
 export default function UserRecoverModalTest() {
   return (
-    <div>
+    <div className="flex flex-col gap-2">
       <Modal>
         <ModalTrigger>
-          <Button>탈퇴 모달</Button>
+          <Button>탈퇴 안내 모달</Button>
         </ModalTrigger>
         <ModalContent>
           <ModalHeader className="border-none" />
@@ -36,6 +38,44 @@ export default function UserRecoverModalTest() {
               <Button>계정 다시 사용하기</Button>
             </ModalFooter>
           </ModalMain>
+        </ModalContent>
+      </Modal>
+
+      <Modal>
+        <ModalTrigger>
+          <Button>탈퇴 폼 모달</Button>
+        </ModalTrigger>
+        <ModalContent className="flex w-full max-w-lg flex-col items-center">
+          <ModalHeader className="w-full border-none" />
+          <ModalMain className="flex w-full flex-col gap-5">
+            <div className="flex flex-col items-center gap-2">
+              <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
+                <RotateCwIcon className="h-5" />
+              </div>
+              <h1 className="text-center text-xl font-bold text-gray-900">
+                계정 다시 사용하기
+              </h1>
+              <p className="text-center text-gray-600">
+                입력하신 이메일로 인증번호를 보내드릴게요.
+              </p>
+            </div>
+            <form className="flex w-full flex-col items-start gap-5">
+              <InputLabel>
+                이메일 <span className="text-danger-500">*</span>
+              </InputLabel>
+              <div className="flex w-full gap-2">
+                <Input
+                  placeholder="가입한 이메일을 입력해주세요."
+                  className="flex-1"
+                />
+                <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+              </div>
+              <Input placeholder="인증번호를 입력해주세요." />
+            </form>
+          </ModalMain>
+          <ModalFooter className="border-none">
+            <Button>계정 다시 사용하기</Button>
+          </ModalFooter>
         </ModalContent>
       </Modal>
     </div>

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -84,6 +84,25 @@ export default function UserRecoverModalTest() {
           </ModalFooter>
         </ModalContent>
       </Modal>
+
+      <Modal>
+        <ModalTrigger>
+          <Button>계정 복구 완료 모달</Button>
+        </ModalTrigger>
+        <ModalContent className="flex w-[90%] max-w-sm flex-col items-center">
+          <ModalMain className="flex flex-col items-center gap-2">
+            <div className="bg-success-500 flex size-7 items-center justify-center rounded-full text-gray-100">
+              <RotateCwIcon className="h-5" />
+            </div>
+            <h1 className="text-center text-xl font-bold text-gray-900">
+              계정 복구 완료!
+            </h1>
+            <p className="text-center text-gray-600">
+              지금 바로 로그인해 보세요
+            </p>
+          </ModalMain>
+        </ModalContent>
+      </Modal>
     </div>
   )
 }

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -17,7 +17,7 @@ export default function UserRecoverModalTest() {
         <ModalTrigger>
           <Button>탈퇴 안내 모달</Button>
         </ModalTrigger>
-        <ModalContent>
+        <ModalContent className="w-[90%]">
           <ModalHeader className="border-none" />
           <ModalMain className="flex flex-col items-center gap-5">
             <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
@@ -34,8 +34,8 @@ export default function UserRecoverModalTest() {
                 계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
               </p>
             </div>
-            <ModalFooter className="border-none">
-              <Button>계정 다시 사용하기</Button>
+            <ModalFooter className="flex w-full justify-center border-none">
+              <Button className="w-[90%] max-w-sm">계정 다시 사용하기</Button>
             </ModalFooter>
           </ModalMain>
         </ModalContent>
@@ -45,7 +45,7 @@ export default function UserRecoverModalTest() {
         <ModalTrigger>
           <Button>탈퇴 폼 모달</Button>
         </ModalTrigger>
-        <ModalContent className="flex w-full max-w-lg flex-col items-center">
+        <ModalContent className="flex w-[90%] max-w-lg flex-col items-center">
           <ModalHeader className="w-full border-none" />
           <ModalMain className="flex w-full flex-col gap-5">
             <div className="flex flex-col items-center gap-2">
@@ -70,11 +70,17 @@ export default function UserRecoverModalTest() {
                 />
                 <AuthVerifyButton>인증코드전송</AuthVerifyButton>
               </div>
-              <Input placeholder="인증번호를 입력해주세요." />
+              <div className="flex w-full gap-2">
+                <Input
+                  placeholder="인증번호를 입력해주세요."
+                  className="flex-1"
+                />
+                <AuthVerifyButton>인증코드전송</AuthVerifyButton>
+              </div>
             </form>
           </ModalMain>
-          <ModalFooter className="border-none">
-            <Button>계정 다시 사용하기</Button>
+          <ModalFooter className="flex w-full justify-center border-none">
+            <Button className="w-[90%] max-w-sm">확인</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -15,7 +15,7 @@ export default function UserRecoverModalTest() {
     <div className="flex flex-col gap-2">
       <Modal>
         <ModalTrigger>
-          <Button>탈퇴 안내 모달</Button>
+          <Button>계정 복구 안내 모달</Button>
         </ModalTrigger>
         <ModalContent className="w-[90%] max-w-lg">
           <ModalHeader className="border-none" />
@@ -43,7 +43,7 @@ export default function UserRecoverModalTest() {
 
       <Modal>
         <ModalTrigger>
-          <Button>탈퇴 폼 모달</Button>
+          <Button>계정 복구 폼 모달</Button>
         </ModalTrigger>
         <ModalContent className="flex w-[90%] max-w-lg flex-col items-center">
           <ModalHeader className="w-full border-none" />

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -30,6 +30,22 @@ export default function UserRecoverModalTest() {
     },
   }
 
+  const [isUserRecoverCompleteModalOpen, setIsUserRecoverCompleteModalOpen] =
+    useState(false)
+
+  const userRecoverCompleteModalControl: ModalContextValue = {
+    isOpen: isUserRecoverCompleteModalOpen,
+    open: () => {
+      setIsUserRecoverCompleteModalOpen(true)
+    },
+    close: () => {
+      setIsUserRecoverCompleteModalOpen(false)
+    },
+    toggle: () => {
+      setIsUserRecoverCompleteModalOpen((prev) => !prev)
+    },
+  }
+
   return (
     <div className="flex flex-col gap-2">
       <Modal>
@@ -71,7 +87,7 @@ export default function UserRecoverModalTest() {
 
       <Modal externalModalControl={userRecoverFormModalControl}>
         <ModalTrigger>
-          <Button>계정 복구 폼 모달</Button>
+          <Button className="hidden">계정 복구 폼 모달</Button>
         </ModalTrigger>
         <ModalContent className="flex w-[90%] max-w-lg flex-col items-center">
           <ModalHeader className="w-full border-none" />
@@ -108,14 +124,23 @@ export default function UserRecoverModalTest() {
             </form>
           </ModalMain>
           <ModalFooter className="flex w-full justify-center border-none">
-            <Button className="w-[90%] max-w-sm">확인</Button>
+            <ModalClose className="flex w-full justify-center">
+              <Button
+                className="w-[90%] max-w-sm"
+                onClick={() => {
+                  userRecoverCompleteModalControl.open()
+                }}
+              >
+                확인
+              </Button>
+            </ModalClose>
           </ModalFooter>
         </ModalContent>
       </Modal>
 
-      <Modal>
+      <Modal externalModalControl={userRecoverCompleteModalControl}>
         <ModalTrigger>
-          <Button>계정 복구 완료 모달</Button>
+          <Button className="hidden">계정 복구 완료 모달</Button>
         </ModalTrigger>
         <ModalContent className="flex w-[90%] max-w-sm flex-col items-center">
           <ModalMain className="flex flex-col items-center gap-2">

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -1,161 +1,33 @@
 import { Button } from '@/components'
-import { AuthVerifyButton } from '@/components/auth/common'
-import { Input, InputLabel } from '@/components/common/input'
-import {
-  Modal,
-  ModalClose,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalMain,
-  ModalTrigger,
-  type ModalContextValue,
-} from '@/components/common/Modal'
-import { MehIcon, RotateCwIcon } from 'lucide-react'
+import { UserRecoverModal } from '@/components/auth/user-recover-modal/'
+import type { ModalContextValue } from '@/components/common/Modal'
 import { useState } from 'react'
 export default function UserRecoverModalTest() {
-  const [isUserRecoverFormModalOpen, setIsUserRecoverFormModalOpen] =
-    useState(false)
+  const [isUserRecoverModalOpen, setIsUserRecoverModalOpen] = useState(false)
 
   const userRecoverFormModalControl: ModalContextValue = {
-    isOpen: isUserRecoverFormModalOpen,
+    isOpen: isUserRecoverModalOpen,
     open: () => {
-      setIsUserRecoverFormModalOpen(true)
+      setIsUserRecoverModalOpen(true)
     },
     close: () => {
-      setIsUserRecoverFormModalOpen(false)
+      setIsUserRecoverModalOpen(false)
     },
     toggle: () => {
-      setIsUserRecoverFormModalOpen((prev) => !prev)
-    },
-  }
-
-  const [isUserRecoverCompleteModalOpen, setIsUserRecoverCompleteModalOpen] =
-    useState(false)
-
-  const userRecoverCompleteModalControl: ModalContextValue = {
-    isOpen: isUserRecoverCompleteModalOpen,
-    open: () => {
-      setIsUserRecoverCompleteModalOpen(true)
-    },
-    close: () => {
-      setIsUserRecoverCompleteModalOpen(false)
-    },
-    toggle: () => {
-      setIsUserRecoverCompleteModalOpen((prev) => !prev)
+      setIsUserRecoverModalOpen((prev) => !prev)
     },
   }
 
   return (
     <div className="flex flex-col gap-2">
-      <Modal>
-        <ModalTrigger>
-          <Button>계정 복구 안내 모달</Button>
-        </ModalTrigger>
-        <ModalContent className="w-[90%] max-w-lg">
-          <ModalHeader className="border-none" />
-          <ModalMain className="flex flex-col items-center gap-5">
-            <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
-              <MehIcon className="h-5" />
-            </div>
-            <h1 className="text-center text-xl font-bold text-gray-900">
-              해당 계정은 탈퇴된 상태예요
-            </h1>
-            <div>
-              <p className="text-center text-gray-600">
-                2025년 9월 20일 이후, 계정 정보는 완전히 삭제돼요.
-              </p>
-              <p className="text-center text-gray-600">
-                계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
-              </p>
-            </div>
-            <ModalFooter className="flex w-full justify-center border-none">
-              <ModalClose className="flex w-full justify-center">
-                <Button
-                  onClick={() => {
-                    userRecoverFormModalControl.open()
-                  }}
-                  className="w-[90%] max-w-sm"
-                >
-                  계정 다시 사용하기
-                </Button>
-              </ModalClose>
-            </ModalFooter>
-          </ModalMain>
-        </ModalContent>
-      </Modal>
-
-      <Modal externalModalControl={userRecoverFormModalControl}>
-        <ModalTrigger>
-          <Button className="hidden">계정 복구 폼 모달</Button>
-        </ModalTrigger>
-        <ModalContent className="flex w-[90%] max-w-lg flex-col items-center">
-          <ModalHeader className="w-full border-none" />
-          <ModalMain className="flex w-full flex-col gap-5">
-            <div className="flex flex-col items-center gap-2">
-              <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
-                <RotateCwIcon className="h-5" />
-              </div>
-              <h1 className="text-center text-xl font-bold text-gray-900">
-                계정 다시 사용하기
-              </h1>
-              <p className="text-center text-gray-600">
-                입력하신 이메일로 인증번호를 보내드릴게요.
-              </p>
-            </div>
-            <form className="flex w-full flex-col items-start gap-5">
-              <InputLabel>
-                이메일 <span className="text-danger-500">*</span>
-              </InputLabel>
-              <div className="flex w-full gap-2">
-                <Input
-                  placeholder="가입한 이메일을 입력해주세요."
-                  className="flex-1"
-                />
-                <AuthVerifyButton>인증코드전송</AuthVerifyButton>
-              </div>
-              <div className="flex w-full gap-2">
-                <Input
-                  placeholder="인증번호를 입력해주세요."
-                  className="flex-1"
-                />
-                <AuthVerifyButton>인증코드확인</AuthVerifyButton>
-              </div>
-            </form>
-          </ModalMain>
-          <ModalFooter className="flex w-full justify-center border-none">
-            <ModalClose className="flex w-full justify-center">
-              <Button
-                className="w-[90%] max-w-sm"
-                onClick={() => {
-                  userRecoverCompleteModalControl.open()
-                }}
-              >
-                확인
-              </Button>
-            </ModalClose>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-
-      <Modal externalModalControl={userRecoverCompleteModalControl}>
-        <ModalTrigger>
-          <Button className="hidden">계정 복구 완료 모달</Button>
-        </ModalTrigger>
-        <ModalContent className="flex w-[90%] max-w-sm flex-col items-center">
-          <ModalMain className="flex flex-col items-center gap-2">
-            <div className="bg-success-500 flex size-7 items-center justify-center rounded-full text-gray-100">
-              <RotateCwIcon className="h-5" />
-            </div>
-            <h1 className="text-center text-xl font-bold text-gray-900">
-              계정 복구 완료!
-            </h1>
-            <p className="text-center text-gray-600">
-              지금 바로 로그인해 보세요
-            </p>
-          </ModalMain>
-        </ModalContent>
-      </Modal>
+      <Button
+        onClick={() => {
+          userRecoverFormModalControl.open()
+        }}
+      >
+        유저 복구 모달
+      </Button>
+      <UserRecoverModal userRecoverModalControl={userRecoverFormModalControl} />
     </div>
   )
 }

--- a/src/tests/UserRecoverModalTest.tsx
+++ b/src/tests/UserRecoverModalTest.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@/components'
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalMain,
+  ModalTrigger,
+} from '@/components/common/Modal'
+import { MehIcon } from 'lucide-react'
+export default function UserRecoverModalTest() {
+  return (
+    <div>
+      <Modal>
+        <ModalTrigger>
+          <Button>탈퇴 모달</Button>
+        </ModalTrigger>
+        <ModalContent>
+          <ModalHeader className="border-none" />
+          <ModalMain className="flex flex-col items-center gap-5">
+            <div className="bg-primary-100 text-primary-500 flex size-7 items-center justify-center rounded-full">
+              <MehIcon className="h-5" />
+            </div>
+            <h1 className="text-center text-xl font-bold text-gray-900">
+              해당 계정은 탈퇴된 상태예요
+            </h1>
+            <div>
+              <p className="text-center text-gray-600">
+                2025년 9월 20일 이후, 계정 정보는 완전히 삭제돼요.
+              </p>
+              <p className="text-center text-gray-600">
+                계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
+              </p>
+            </div>
+            <ModalFooter className="border-none">
+              <Button>계정 다시 사용하기</Button>
+            </ModalFooter>
+          </ModalMain>
+        </ModalContent>
+      </Modal>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🚀 PR 요약

> Feature: 회원 복구 모달 UI

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 각 단계별 모달 및 모달 간 이동
- 4가지 모달
  - UserRecoverModal: 아래 3개의 모달을 감싸는 wrapper 컴포넌트. 상위 컴포넌트에서는 해당 컴포넌트만 사용.
  - UserRecoverNoticeModal: 첫 번째로 보이는 모달. 계정이 삭제됨을 알려주는 모달
  - UserRecoverFormModal: 두 번째로 보이는 모달. 계정 복구 코드를 제출하는 모달
  - UserRecoverCompleteModal: 마지막으로 보이는 모달. 계정 복구가 완료됨을 알려주는 모달 

### 참고 사항
- 회원가입이랑 비슷하게 UI 맞추려고 노력했는데 혹시 수정할 부분 있으면 말씀해주세요!
- 사용 방법이나 구현 방법에 궁금한 점이 있으면 말씀해주세요!

- TODO
  - 폼에 react-hook-form 및 zod 적용
  - 복구 성공 및 실패 시 토스트
  - 복구 mutation 훅
  - msw 연결

### 스크린 샷

https://github.com/user-attachments/assets/208f8e39-e0fa-4d52-aa72-0e2503e9be2e

## 🔗 연관된 이슈

> closes #207 
