### PR TITLE
Refactor: 토스트 메시지 컴포넌트 수정

### DIFF
--- a/src/components/common/toast/ToastContainer.tsx
+++ b/src/components/common/toast/ToastContainer.tsx
@@ -15,8 +15,14 @@ function ToastContainer() {
 
   return (
     <div className="fixed top-18 right-1 z-10 w-112 space-y-1">
-      {renderedToasts.map(({ id, type, content }) => (
-        <ToastItem key={id} id={id} type={type} content={content} />
+      {renderedToasts.map(({ id, type, title, content }) => (
+        <ToastItem
+          key={id}
+          id={id}
+          type={type}
+          title={title}
+          content={content}
+        />
       ))}
     </div>
   )

--- a/src/components/common/toast/ToastContainer.tsx
+++ b/src/components/common/toast/ToastContainer.tsx
@@ -14,7 +14,7 @@ function ToastContainer() {
   }, [debouncedToasts])
 
   return (
-    <div className="fixed top-18 right-1 z-10 w-112 space-y-1">
+    <div className="fixed top-18 right-1 z-100 w-112 space-y-1">
       {renderedToasts.map(({ id, type, title, content }) => (
         <ToastItem
           key={id}

--- a/src/components/common/toast/ToastItem.tsx
+++ b/src/components/common/toast/ToastItem.tsx
@@ -28,9 +28,9 @@ const TOAST_COLORS = {
 }
 
 const TOAST_TITLE = {
-  success: '성공적으로 저장되었습니다',
-  warning: '주의가 필요합니다',
-  error: '오류가 발생했습니다',
+  success: '성공적으로 저장되었습니다 ✅',
+  warning: '주의가 필요합니다 ⚠️',
+  error: '오류가 발생했습니다 ❌',
 }
 
 const TOAST_ICON = {
@@ -39,9 +39,13 @@ const TOAST_ICON = {
   error: CircleX,
 }
 
-function ToastItem({ id, type, content = '' }: Toast) {
+function ToastItem({
+  id,
+  type,
+  title = TOAST_TITLE[type],
+  content = '',
+}: Toast) {
   const styles = TOAST_COLORS[type]
-  const title = TOAST_TITLE[type]
   const Icon = TOAST_ICON[type]
   const { removeToast } = useToastStore()
 
@@ -57,14 +61,14 @@ function ToastItem({ id, type, content = '' }: Toast) {
         styles.bg
       )}
     >
-      <Icon className={cn('relative bottom-[1.75px] w-[18px]', styles.icon)} />
+      <Icon className={cn('relative bottom-[1.75px] w-4.5', styles.icon)} />
       <div className="flex-1 text-sm">
         <h4 className={styles.title}>{title}</h4>
         <p className={styles.content}>{content}</p>
       </div>
       <X
         className={cn(
-          'relative bottom-[1.75px] w-[18px] cursor-pointer',
+          'relative bottom-[1.75px] w-4.5 cursor-pointer',
           styles.icon
         )}
         onClick={handleClickDelete}

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -30,7 +30,7 @@ export default function useLogin(
       setAccessToken(newAccessToken)
       setIsLoggedIn(true)
       await qc.invalidateQueries({ queryKey: ['users', 'me'] })
-      triggerToast('success', '로그인이 완료되었습니다.')
+      triggerToast('success', 'Login 🎉', '로그인이 완료되었습니다.')
       navigate('/')
     },
     onError: () => {

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -22,7 +22,7 @@ export default function useLogout(options?: UseMutationOptions) {
       setIsLoggedIn(false)
       clearAccessToken()
       qc.removeQueries({ queryKey: ['users', 'me'] })
-      triggerToast('success', '로그아웃이 완료되었습니다.')
+      triggerToast('success', 'Logout 👋', '로그아웃이 완료되었습니다.')
     },
     ...options,
   })

--- a/src/hooks/api/useAxiosInterceptor.ts
+++ b/src/hooks/api/useAxiosInterceptor.ts
@@ -36,7 +36,7 @@ export default function useAxiosInterceptor() {
 
     if (response?.status === 401 && isTokenRefresh && isMypageLocated) {
       navigate('/auth/login')
-      triggerToast('error', '로그인이 만료되었습니다. 다시 로그인 해주세요.')
+      triggerToast('error', '로그인이 만료되었습니다', '다시 로그인 해주세요.')
     }
 
     return Promise.reject(error)

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,13 +1,29 @@
 import { useToastStore } from '@/store'
 import type { Toast } from '@/types'
 
-const TIMEOUT = 3000
+const TIMEOUT = 3000 as const
 
 function useToast() {
   const { addToast, removeToast } = useToastStore.getState()
 
-  const triggerToast = (type: Toast['type'], content: Toast['content']) => {
-    const newToast = { id: Date.now(), type: type, content: content }
+  function triggerToast(type: Toast['type'], content: Toast['content']): void
+  function triggerToast(
+    type: Toast['type'],
+    title: Toast['title'],
+    content: Toast['content']
+  ): void
+
+  function triggerToast(
+    a: Toast['type'],
+    b: Toast['title'] | Toast['content'],
+    c?: Toast['content']
+  ) {
+    const newToast = {
+      id: Date.now(),
+      type: a,
+      title: c ? (b as Toast['title']) : undefined,
+      content: c ? (c as Toast['content']) : (b as Toast['content']),
+    }
 
     addToast(newToast)
 

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -19,13 +19,15 @@ function useVerificationCode() {
     email: useTimer(TIMER_DURATION_MS, () =>
       triggerToast(
         'warning',
-        '이메일 인증 시간이 만료되었습니다. 다시 시도해주세요.'
+        '이메일 인증 시간이 만료되었습니다',
+        '다시 시도해주세요'
       )
     ),
     phoneNumber: useTimer(TIMER_DURATION_MS, () =>
       triggerToast(
         'warning',
-        '휴대전화 번호 인증 시간이 만료되었습니다. 다시 시도해주세요.'
+        '휴대전화 번호 인증 시간이 만료되었습니다',
+        '다시 시도해주세요'
       )
     ),
   }
@@ -34,7 +36,7 @@ function useVerificationCode() {
     await new Promise((resolve) => setTimeout(resolve, 1000))
     SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
     timer[label].startTimer()
-    triggerToast('success', '인증 코드를 전송했습니다.')
+    triggerToast('success', '인증 코드를 전송했습니다.', '확인 후 입력해주세요')
   }
 
   const handleCodeVerify = async (label: 'email' | 'phoneNumber') => {
@@ -42,7 +44,11 @@ function useVerificationCode() {
     SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
     SetIsCodeSent((prev) => ({ ...prev, [label]: false }))
     timer[label].resetTimer()
-    triggerToast('success', '인증을 완료했습니다!')
+    triggerToast(
+      'success',
+      '인증코드가 확인되었습니다',
+      '다음 단계를 진행해 주세요'
+    )
   }
 
   return { isCodeSent, isCodeVerified, timer, handleCodeSend, handleCodeVerify }

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -54,7 +54,7 @@ function Signup() {
 
   const onSubmit = async () => {
     await new Promise((resolve) => setTimeout(resolve, 500))
-    triggerToast('success', '회원가입이 완료되었습니다!')
+    triggerToast('success', 'Signup 😎', '회원가입이 완료되었습니다')
     reset()
     navigate('/auth/login')
   }
@@ -68,7 +68,11 @@ function Signup() {
   const handleDuplicateCheck = async () => {
     await new Promise((resolve) => setTimeout(resolve, 1000))
     setIsDuplicateChecked(true)
-    triggerToast('success', '사용 가능한 닉네임입니다.')
+    triggerToast(
+      'success',
+      '사용 가능한 닉네임입니다.',
+      '다음 단계를 진행해 주세요'
+    )
   }
 
   return (

--- a/src/tests/AuthFormVerificationTest.tsx
+++ b/src/tests/AuthFormVerificationTest.tsx
@@ -22,7 +22,7 @@ function AuthFormVerificationTest() {
 
   const onSubmit = async (data: AuthSchemaType) => {
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    triggerToast('success', 'Auth 유효성 검사 성공!')
+    triggerToast('success', 'Test Success ✅', 'Auth 유효성 검사 성공!')
     console.log('입력 내용: ', data)
     reset()
   }

--- a/src/tests/ToastTest.tsx
+++ b/src/tests/ToastTest.tsx
@@ -8,6 +8,7 @@ function ToastTest() {
     <section className="flex h-1000 flex-col gap-10">
       <h3 className="text-center text-xl font-semibold">토스트 메시지 Test</h3>
       <article className="flex w-fit flex-col gap-6">
+        <h4 className="text-lg font-medium">타이틀 추가 X</h4>
         <Button
           onClick={() => triggerToast('success', '성공 알림 테스트')}
           className="bg-success-500 hover:bg-success-600 active:bg-success-800 rounded-xl p-4 text-white"
@@ -22,6 +23,45 @@ function ToastTest() {
         </Button>
         <Button
           onClick={() => triggerToast('error', '에러 알림 테스트')}
+          className="bg-danger-500 hover:bg-danger-600 active:bg-danger-800 rounded-xl p-4 text-white"
+        >
+          에러 토스트
+        </Button>
+      </article>
+      <article className="flex w-fit flex-col gap-6">
+        <h4 className="text-lg font-medium">타이틀 추가 O</h4>
+        <Button
+          onClick={() =>
+            triggerToast(
+              'success',
+              '요청에 성공했습니다',
+              '로그인을 완료했습니다.'
+            )
+          }
+          className="bg-success-500 hover:bg-success-600 active:bg-success-800 rounded-xl p-4 text-white"
+        >
+          성공 토스트
+        </Button>
+        <Button
+          onClick={() =>
+            triggerToast(
+              'warning',
+              '인증코드 유효 시간이 만료되었습니다',
+              '다시 시도해주세요'
+            )
+          }
+          className="bg-primary-500 rounded-xl p-4 text-white"
+        >
+          경고 토스트
+        </Button>
+        <Button
+          onClick={() =>
+            triggerToast(
+              'error',
+              '존재하지 않는 이메일입니다',
+              '다시 입력해주세요'
+            )
+          }
           className="bg-danger-500 hover:bg-danger-600 active:bg-danger-800 rounded-xl p-4 text-white"
         >
           에러 토스트

--- a/src/types/components/toast.ts
+++ b/src/types/components/toast.ts
@@ -1,5 +1,6 @@
 export interface Toast {
   id: number
   type: 'success' | 'warning' | 'error'
+  title?: string
   content: string
 }


### PR DESCRIPTION
## 🚀 PR 요약

토스트 메시지 컴포넌트의 기본 title 값을 수정하고, 원한다면 title을 직접 입력할 수 있게 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **ToastItem** 내의 `TOAST_TITLE` 값에 이모지 추가
- triggerToast의 인자가 2개면 **type**, **content**로 해석, 인자가 3개면 **type, title, content**로 해석하도록 수정
  - 예시1: `triggerToast('success', '인증이 완료되었습니다')` (기본 title 적용)
    <img width="463" height="112" alt="image" src="https://github.com/user-attachments/assets/0e3e58d3-7873-43a0-abf2-002fd3924119" />
  - 예시2: `triggerToast('success', '인증 완료', '다음 단계를 진행해주세요')` (인자로 추가한 title 적용)
    <img width="471" height="128" alt="image" src="https://github.com/user-attachments/assets/6859789a-4816-48ca-9f3d-2fce1289e902" />

### 스크린 샷

![StudyHub-Chrome2025-09-2316-13-58-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c605d668-9525-4c98-98c6-9502a624811d)

## 🔗 연관된 이슈

> closes #157
