### PR TITLE
Feature: 내 정보 조회 api 호출 로직 구현 

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -5,7 +5,7 @@ import { AVATAR_SIZE } from '@/constants/avatar-sizes'
 import { User as UserIcon } from 'lucide-react'
 
 const AvatarImage = cva(
-  'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center border-primary-200 border',
+  'text-primary-600 bg-primary-100 rounded-full relative shrink-0 flex items-center justify-center',
   {
     variants: {
       size: AVATAR_SIZE,

--- a/src/components/common/skeleton/UserInfoSkeleton.tsx
+++ b/src/components/common/skeleton/UserInfoSkeleton.tsx
@@ -1,0 +1,12 @@
+import { SkeletonRectangle } from './SkeletonItem'
+
+function UserInfoSkeleton() {
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <SkeletonRectangle height={8} />
+      <SkeletonRectangle height={18} />
+    </div>
+  )
+}
+
+export default UserInfoSkeleton

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -16,6 +16,8 @@ import Avatar from '@/components/common/Avatar'
 import AuthLayout from '@/components/layout/AuthLayout'
 import Notification from '@/components/notification/Notification'
 import Dropdown from '@/components/common/Dropdown'
+import EmptyDataState from '@/components/common/state/EmptyDataState'
+import UserInfoSkeleton from './common/skeleton/UserInfoSkeleton'
 
 export {
   Badge,
@@ -35,4 +37,6 @@ export {
   AuthLayout,
   Notification,
   Dropdown,
+  EmptyDataState,
+  UserInfoSkeleton,
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -17,7 +17,7 @@ import AuthLayout from '@/components/layout/AuthLayout'
 import Notification from '@/components/notification/Notification'
 import Dropdown from '@/components/common/Dropdown'
 import EmptyDataState from '@/components/common/state/EmptyDataState'
-import UserInfoSkeleton from './common/skeleton/UserInfoSkeleton'
+import UserInfoSkeleton from '@/components/common/skeleton/UserInfoSkeleton'
 
 export {
   Badge,

--- a/src/components/my-page/my-info/InfoDescription.tsx
+++ b/src/components/my-page/my-info/InfoDescription.tsx
@@ -1,6 +1,4 @@
-import type { ReactNode } from 'react'
-
-interface InfoDescription {
+export interface InfoDescription {
   title: string
   detail: string
 }
@@ -9,9 +7,7 @@ interface InfoDescriptionProps {
   infoList: InfoDescription[]
 }
 
-export function UserInfoDescription({
-  infoList,
-}: InfoDescriptionProps): ReactNode {
+export function UserInfoDescription({ infoList }: InfoDescriptionProps) {
   return (
     <dl className="grid grid-cols-1 gap-6 md:grid-cols-2">
       {infoList.map((list, index) => (

--- a/src/components/my-page/side-bar/MyPageSideBarProfile.tsx
+++ b/src/components/my-page/side-bar/MyPageSideBarProfile.tsx
@@ -4,9 +4,9 @@ import { useUserInformation } from '@/hooks/api'
 export default function MyPageSideBarProfile() {
   const { data: userInfo } = useUserInformation()
   if (!userInfo) return '로그인이 필요합니다.'
-  const signUpDate = new Date(userInfo.birthday)
+  const signUpDate = new Date(userInfo.createdAt)
   const signUpYear = signUpDate.getFullYear()
-  const signUpMonth = signUpDate.getMonth()
+  const signUpMonth = signUpDate.getMonth() + 1
 
   return (
     <div className="flex flex-col items-center justify-start">

--- a/src/components/my-page/side-bar/MyPageSideBarProfile.tsx
+++ b/src/components/my-page/side-bar/MyPageSideBarProfile.tsx
@@ -1,34 +1,23 @@
 import { Avatar } from '@/components'
-
-//임시 유저 정보 인터페이스 (추후 삭제)
-interface UserInformation {
-  username: string
-  email: string
-  signUpDay: Date
-  profileImageUrl?: string
-}
-
-//임시 유저 정보 (추후 삭제)
-const dummyUserInfo: UserInformation = {
-  username: 'test1234',
-  email: 'test@test.com',
-  signUpDay: new Date(),
-  profileImageUrl: 'https://dummyimage.com/600x400/000/fff',
-}
+import { useUserInformation } from '@/hooks/api'
 
 export default function MyPageSideBarProfile() {
-  //TODO: 나중에 전역상태에서 실제 유저 데이터 불러오기
-  const { username, email, signUpDay, profileImageUrl } = dummyUserInfo
+  const { data: userInfo } = useUserInformation()
+  if (!userInfo) return '로그인이 필요합니다.'
+  const signUpDate = new Date(userInfo.birthday)
+  const signUpYear = signUpDate.getFullYear()
+  const signUpMonth = signUpDate.getMonth()
 
-  const signUpYear = signUpDay.getFullYear()
-  const signUpMonth = signUpDay.getMonth()
-
-  //16 4 8
   return (
     <div className="flex flex-col items-center justify-start">
-      <Avatar src={profileImageUrl} size="2xl" state="none" className="mb-4" />
-      <span className="text-heading5 mb-1 text-gray-900">{username}</span>
-      <span className="text-secondary mb-2">{email}</span>
+      <Avatar
+        src={userInfo.profileImageUrl}
+        size="2xl"
+        state="none"
+        className="mb-4"
+      />
+      <span className="text-heading5 mb-1 text-gray-900">{userInfo.name}</span>
+      <span className="text-secondary mb-2">{userInfo.email}</span>
       <span className="text-xs text-gray-500">{`가입일: ${signUpYear}년 ${signUpMonth}월`}</span>
     </div>
   )

--- a/src/hooks/api/auth/useUserInformation.ts
+++ b/src/hooks/api/auth/useUserInformation.ts
@@ -20,6 +20,7 @@ export default function useUserInformation<T = UserInformation>(
         ...data,
         phoneNumber: data.phone_number,
         profileImageUrl: data.profile_image_url,
+        createdAt: data.created_at,
       }
     },
     enabled: isLoggedIn,

--- a/src/mocks/data/user-information-data.ts
+++ b/src/mocks/data/user-information-data.ts
@@ -8,6 +8,7 @@ export const userInformationMock = [
     birthday: '1990-01-01',
     gender: 'female',
     profile_image_url: 'https://picsum.photos/id/65/200/300',
+    created_at: '2023-05-12T10:20:30Z',
   },
   {
     id: 2,
@@ -18,6 +19,7 @@ export const userInformationMock = [
     birthday: '1990-02-02',
     gender: 'male',
     profile_image_url: 'https://picsum.photos/id/30/200/300',
+    created_at: '2024-02-01T15:45:00Z',
   },
   {
     id: 3,
@@ -28,5 +30,6 @@ export const userInformationMock = [
     birthday: '1990-03-03',
     gender: 'male',
     profile_image_url: null,
+    created_at: '2025-01-10T08:00:00Z',
   },
 ]

--- a/src/pages/my-page/AppliedRecruitment.tsx
+++ b/src/pages/my-page/AppliedRecruitment.tsx
@@ -1,5 +1,4 @@
-import { ListItemSkeleton } from '@/components'
-import EmptyDataState from '@/components/common/state/EmptyDataState'
+import { ListItemSkeleton, EmptyDataState } from '@/components'
 import { useAppliedRecruitment } from '@/hooks/api'
 import {
   AppliedRecruitmentCard,

--- a/src/pages/my-page/CompletedStudy.tsx
+++ b/src/pages/my-page/CompletedStudy.tsx
@@ -1,5 +1,4 @@
-import { ImageCardSkeleton } from '@/components'
-import EmptyDataState from '@/components/common/state/EmptyDataState'
+import { ImageCardSkeleton, EmptyDataState } from '@/components'
 import { useCompletedStudy } from '@/hooks/api'
 import { CompletedStudyImageCard } from '@/components/my-page'
 

--- a/src/pages/my-page/MyInfo.tsx
+++ b/src/pages/my-page/MyInfo.tsx
@@ -1,16 +1,24 @@
-import type { ReactNode } from 'react'
 import {
   UserInfoDescription,
   InfoUpdate,
   PasswordChange,
   Withdrawal,
 } from '@/components/my-page'
-import { Avatar } from '@/components'
+import { Avatar, UserInfoSkeleton } from '@/components'
+import { mapUserInfoToDescription } from '@/utils/map-user-info'
+import { useUserInformation } from '@/hooks/api'
 
-export function MyInfo(): ReactNode {
+export function MyInfo() {
+  const { data: userInfo, isPending } = useUserInformation()
+  if (!userInfo) return '로그인이 필요합니다.'
+
   return (
     <main>
-      <section className="flex flex-col gap-8 pb-16" aria-labelledby="myInfo">
+      {/* 내 정보 섹션 */}
+      <section
+        className="flex flex-col gap-8 pb-16"
+        aria-labelledby="myInfoHeading"
+      >
         <header className="flex justify-between">
           <div className="flex flex-col">
             <h2 className="text-heading3 pb-2">내 정보</h2>
@@ -21,23 +29,27 @@ export function MyInfo(): ReactNode {
           <InfoUpdate />
         </header>
         <figure className="flex flex-col items-center gap-4">
-          <Avatar size="5xl" state="none" />
+          <Avatar
+            size="5xl"
+            state="none"
+            src={userInfo.profileImageUrl ?? undefined}
+          />
           <figcaption className="text-heading5">프로필 이미지</figcaption>
         </figure>
-        <UserInfoDescription
-          infoList={[
-            { title: '이메일', detail: 'kim.dev@example.com' },
-            { title: '휴대폰 번호', detail: '' },
-            { title: '닉네임', detail: '' },
-            { title: '생년월일', detail: '' },
-            { title: '이름', detail: '' },
-          ]}
-        />
+        {isPending ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {[...Array(5)].map((_, i) => (
+              <UserInfoSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <UserInfoDescription infoList={mapUserInfoToDescription(userInfo)} />
+        )}
       </section>
-
+      {/* 비밀번호 섹션 */}
       <section
         className="border-y border-gray-200 py-16 pt-8"
-        aria-labelledby="passwordChange"
+        aria-labelledby="passwordChangeHeading"
       >
         <header className="flex justify-between">
           <div className="flex flex-col">
@@ -49,7 +61,8 @@ export function MyInfo(): ReactNode {
           <PasswordChange />
         </header>
       </section>
-      <section className="py-16 pt-8" aria-labelledby="unregister">
+      {/* 회원 탈퇴 섹션 */}
+      <section className="py-16 pt-8" aria-labelledby="withdrawalHeading">
         <header className="flex justify-between">
           <div className="flex flex-col">
             <h2 className="text-heading3 pb-2">회원 탈퇴</h2>

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -7,4 +7,5 @@ export interface UserInformation {
   birthday: string
   gender: 'male' | 'female'
   profileImageUrl?: string
+  createdAt: Date
 }

--- a/src/utils/map-user-info.ts
+++ b/src/utils/map-user-info.ts
@@ -1,0 +1,15 @@
+import type { UserInformation } from '@/types'
+import type { InfoDescription } from '@/components/my-page/my-info/InfoDescription'
+
+// 마이페이지 내정보 조회를 위한 유틸 생성
+export function mapUserInfoToDescription(
+  user: UserInformation
+): InfoDescription[] {
+  return [
+    { title: '이메일', detail: user.email ?? '' },
+    { title: '휴대폰 번호', detail: user.phoneNumber ?? '' },
+    { title: '닉네임', detail: user.nickname ?? '' },
+    { title: '생년월일', detail: user.birthday ?? '' },
+    { title: '이름', detail: user.name ?? '' },
+  ]
+}


### PR DESCRIPTION
## 🚀 PR 요약

> 내 정보를 조회하는 api 호출 로직을 구현했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 기존 mockdata / hook 사용
- userInfoDescrition 컴포넌트에 props로 전달할 객체 유틸 생성 적용
- 내 정보 조회란에 맞는 신규 skeleton 생성 후 적용

### 참고 사항

- api 호출 훅에 수동으로 snake_case -> camelCase 변환해주던 spread 변환을 자동으로 적용해주는 humps 라이브러리가 있다고 함.
- 스크린샷을 찍다보니 마이페이지 사이드바의 유저 정보 반영도 같이 머지하는 편이 좋을 것 같아 추가작업 예정.
- '로그인이 필요합니다'를 대체할 비로그인 안내 에러처리 컴포넌트 생성 후 추가 예정.
### 스크린 샷

<img width="949" height="760" alt="내 정보 조회" src="https://github.com/user-attachments/assets/86f9c019-6dc2-4d6e-9a64-8cb9007057e1" />
<img width="1728" height="1168" alt="내 정보 조회" src="https://github.com/user-attachments/assets/fd966884-ebb8-4ddc-a806-ae1573c7c8f6" />


## 🔗 연관된 이슈

> closes #215 
