### PR TITLE
refactor: useVerificationCode에 탈퇴 회원 복구 로직 추가

### DIFF
--- a/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
@@ -10,8 +10,7 @@ import {
   ModalMain,
   type ModalContextValue,
 } from '@/components/common/Modal'
-import { useToast, useVerificationCode } from '@/hooks'
-import { useUserRecoverVerify, useUserRecoverSendCode } from '@/hooks/api'
+import { useVerificationCode } from '@/hooks'
 import {
   UserRecoverSchema,
   type UserRecover,
@@ -43,29 +42,22 @@ export default function UserRecoverFormModal({
 
   const isEmailNotValid = getFieldState('email').invalid || !watch('email')
 
-  //mutation 코드는 이후 useVerificationCode 훅 안으로 이동 예정!!
-  const { triggerToast } = useToast()
-  const { mutate: sendEmail } = useUserRecoverSendCode({
-    onSuccess: () => {
-      // TODO: 실제 입력한 이메일 값 적용하도록 수정
-      handleCodeSend('email', 'test@test.com')
-    },
-    onError: () => {
-      triggerToast('error', '이메일 전송 실패')
-    },
-  })
-  const { mutate: verifyEmail } = useUserRecoverVerify({
-    // TODO: 실제 입력한 이메일 값과 전송받은 인증코드 적용하도록 수정
-    onSuccess: () => {
-      handleCodeVerify('email', {
-        email: 'test@test.com',
-        verificationCode: '123abc',
-      })
-    },
-    onError: () => {
-      triggerToast('error', '이메일 인증 실패')
-    },
-  })
+  const handleCodeSendClick: React.MouseEventHandler<HTMLButtonElement> = (
+    e
+  ) => {
+    e.preventDefault()
+    handleCodeSend('userRecover', getValues('email'))
+  }
+
+  const handleCodeVerifyClick: React.MouseEventHandler<HTMLButtonElement> = (
+    e
+  ) => {
+    e.preventDefault()
+    handleCodeVerify('userRecover', {
+      email: getValues('email'),
+      verificationCode: getValues('verificationCode'),
+    })
+  }
 
   return (
     <Modal externalModalControl={userRecoverFormModalControl}>
@@ -93,13 +85,11 @@ export default function UserRecoverFormModal({
               />
               <AuthVerifyButton
                 type="button"
-                disabled={isEmailNotValid || timer.email.isCounting}
-                onClick={() => {
-                  sendEmail(getValues('email'))
-                }}
+                disabled={isEmailNotValid || timer.userRecover.isCounting}
+                onClick={handleCodeSendClick}
               >
-                {timer.email.isCounting
-                  ? `재전송 (${timer.email.formatMMSS(timer.email.remainSecond)})`
+                {timer.userRecover.isCounting
+                  ? `재전송 (${timer.userRecover.formatMMSS(timer.userRecover.remainSecond)})`
                   : '인증코드전송'}
               </AuthVerifyButton>
             </div>
@@ -111,11 +101,8 @@ export default function UserRecoverFormModal({
               />
               <AuthVerifyButton
                 type="button"
-                disabled={!isCodeSent.email}
-                onClick={() => {
-                  const { email, verificationCode } = getValues()
-                  verifyEmail({ email, verificationCode })
-                }}
+                disabled={!isCodeSent.userRecover}
+                onClick={handleCodeVerifyClick}
               >
                 인증코드확인
               </AuthVerifyButton>
@@ -128,7 +115,7 @@ export default function UserRecoverFormModal({
             onClick={() => {
               userRecoverCompleteModalOpen()
             }}
-            disabled={!isCodeVerified.email}
+            disabled={!isCodeVerified.userRecover}
           >
             <ModalClose className="flex w-full justify-center">확인</ModalClose>
           </Button>

--- a/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
@@ -11,7 +11,7 @@ import {
   type ModalContextValue,
 } from '@/components/common/Modal'
 import { useToast, useVerificationCode } from '@/hooks'
-import { useUserRecover, useUserRecoverEmailSend } from '@/hooks/api'
+import { useUserRecoverVerify, useUserRecoverSendCode } from '@/hooks/api'
 import {
   UserRecoverSchema,
   type UserRecover,
@@ -45,7 +45,7 @@ export default function UserRecoverFormModal({
 
   //mutation 코드는 이후 useVerificationCode 훅 안으로 이동 예정!!
   const { triggerToast } = useToast()
-  const { mutate: sendEmail } = useUserRecoverEmailSend({
+  const { mutate: sendEmail } = useUserRecoverSendCode({
     onSuccess: () => {
       // TODO: 실제 입력한 이메일 값 적용하도록 수정
       handleCodeSend('email', 'test@test.com')
@@ -54,7 +54,7 @@ export default function UserRecoverFormModal({
       triggerToast('error', '이메일 전송 실패')
     },
   })
-  const { mutate: verifyEmail } = useUserRecover({
+  const { mutate: verifyEmail } = useUserRecoverVerify({
     // TODO: 실제 입력한 이메일 값과 전송받은 인증코드 적용하도록 수정
     onSuccess: () => {
       handleCodeVerify('email', {

--- a/src/hooks/api/auth/useUserRecover.ts
+++ b/src/hooks/api/auth/useUserRecover.ts
@@ -1,17 +1,35 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
 import type { userRecoverVerifyBody } from '@/types/api-request-types/user-recover-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 
 export default function useUserRecover(
   options?: UseMutationOptions<void, Error, userRecoverVerifyBody>
 ) {
+  const { triggerToast } = useToast()
+
   return useMutation({
     mutationFn: async ({ email, verificationCode }) => {
       await api.post(`${MSW_BASE_URL}/auth/recover-account/verify`, {
         email,
         verification_code: verificationCode,
       })
+    },
+    onSuccess: () => {
+      triggerToast('success', '인증 완료 ✅', '계정 정보가 복구되었습니다.')
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.status === 400) {
+          triggerToast('error', '잘못된 인증코드입니다.')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요.')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요.')
+      }
     },
     ...options,
   })

--- a/src/hooks/api/auth/useUserRecoverEmailSend.ts
+++ b/src/hooks/api/auth/useUserRecoverEmailSend.ts
@@ -1,13 +1,38 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 
 export default function useUserRecoverEmailSend(
   options?: UseMutationOptions<void, Error, string>
 ) {
+  const { triggerToast } = useToast()
+
   return useMutation({
     mutationFn: async (email) => {
       await api.post(`${MSW_BASE_URL}/auth/recover-account/send`, { email })
+    },
+    onSuccess: () => {
+      triggerToast(
+        'success',
+        '이메일 인증 코드를 전송했습니다 ✉️',
+        '확인 후 입력해주세요'
+      )
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.status === 400) {
+          triggerToast(
+            'error',
+            '탈퇴 계정이 아니거나 존재하지않는 이메일입니다.'
+          )
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요.')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요.')
+      }
     },
     ...options,
   })

--- a/src/hooks/api/auth/useUserRecoverSendCode.ts
+++ b/src/hooks/api/auth/useUserRecoverSendCode.ts
@@ -4,7 +4,7 @@ import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
-export default function useUserRecoverEmailSend(
+export default function useUserRecoverSendCode(
   options?: UseMutationOptions<void, Error, string>
 ) {
   const { triggerToast } = useToast()

--- a/src/hooks/api/auth/useUserRecoverVerify.ts
+++ b/src/hooks/api/auth/useUserRecoverVerify.ts
@@ -1,12 +1,12 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
 import useToast from '@/hooks/useToast'
-import type { userRecoverVerifyBody } from '@/types/api-request-types/user-recover-request-types'
+import type { UserRecoverVerifyBody } from '@/types/api-request-types/user-recover-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
 export default function useUserRecoverVerify(
-  options?: UseMutationOptions<void, Error, userRecoverVerifyBody>
+  options?: UseMutationOptions<void, Error, UserRecoverVerifyBody>
 ) {
   const { triggerToast } = useToast()
 

--- a/src/hooks/api/auth/useUserRecoverVerify.ts
+++ b/src/hooks/api/auth/useUserRecoverVerify.ts
@@ -5,7 +5,7 @@ import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
-export default function useUserRecover(
+export default function useUserRecoverVerify(
   options?: UseMutationOptions<void, Error, userRecoverVerifyBody>
 ) {
   const { triggerToast } = useToast()

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -8,8 +8,8 @@ import useInfiniteBookmarkedRecruitment from '@/hooks/api/bookmarked/useInfinite
 import useInfiniteBookmarkedLecture from '@/hooks/api/bookmarked/useInfiniteBookmarkedLecture'
 import useLogin from '@/hooks/api/auth/useLogin'
 import useBookmarkedRecruitment from '@/hooks/api/bookmarked/useBookmarkedRecruitments'
-import useUserRecover from '@/hooks/api/auth/useUserRecover'
-import useUserRecoverEmailSend from '@/hooks/api/auth/useUserRecoverEmailSend'
+import useUserRecoverVerify from '@/hooks/api/auth/useUserRecoverVerify'
+import useUserRecoverSendCode from '@/hooks/api/auth/useUserRecoverSendCode'
 import useToggleLectureBookmark from '@/hooks/api/bookmarked/useToggleLectureBookmark'
 import useToggleRecruitmentBookmark from '@/hooks/api/bookmarked/useToggleRecruitmentBookmark'
 
@@ -24,8 +24,8 @@ export {
   useInfiniteBookmarkedLecture,
   useLogin,
   useBookmarkedRecruitment,
-  useUserRecover,
-  useUserRecoverEmailSend,
+  useUserRecoverVerify,
+  useUserRecoverSendCode,
   useToggleLectureBookmark,
   useToggleRecruitmentBookmark,
 }

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -12,23 +12,36 @@ import type {
   UserPhoneVerify,
 } from '@/types/api-request-types/auth-request-types'
 import { formattedPhoneToE164KR } from '@/utils/formatted-phone'
+import { useUserRecoverSendCode, useUserRecoverVerify } from '@/hooks/api'
+import type { UserRecoverVerifyBody } from '@/types/api-request-types/user-recover-request-types'
 
 const TIMER_DURATION_MS = 180000
+type labelType = 'email' | 'phoneNumber' | 'userRecover'
+
+interface VerifyDataMap {
+  email: UserEmailVerify
+  phoneNumber: UserPhoneVerify
+  userRecover: UserRecoverVerifyBody
+}
 
 function useVerificationCode() {
   const { triggerToast } = useToast()
   const emailSendCode = useEmailSendCode()
   const phoneSendCode = usePhoneSendCode()
+  const userRecoverSendCode = useUserRecoverSendCode()
   const emailVerify = useEmailVerify()
   const phoneVerify = usePhoneVerify()
+  const userRecoverVerify = useUserRecoverVerify()
 
   const [isCodeSent, SetIsCodeSent] = useState({
     email: false,
     phoneNumber: false,
+    userRecover: false,
   })
   const [isCodeVerified, SetIsCodeVerified] = useState({
     email: false,
     phoneNumber: false,
+    userRecover: false,
   })
   const timer = {
     email: useTimer(TIMER_DURATION_MS, () =>
@@ -45,12 +58,16 @@ function useVerificationCode() {
         '다시 시도해주세요'
       )
     ),
+    userRecover: useTimer(TIMER_DURATION_MS, () =>
+      triggerToast(
+        'warning',
+        '이메일 인증 시간이 만료되었습니다',
+        '다시 시도해주세요'
+      )
+    ),
   }
 
-  const handleCodeSend = async (
-    label: 'email' | 'phoneNumber',
-    value: string
-  ) => {
+  const handleCodeSend = async (label: labelType, value: string) => {
     if (label === 'email') {
       const data: UserEmailSendCode = { email: value }
       emailSendCode.mutate(data)
@@ -60,13 +77,16 @@ function useVerificationCode() {
       const data: UserPhoneSendCode = { phoneNumber: phoneNumberE164KR }
       phoneSendCode.mutate(data)
     }
+    if (label === 'userRecover') {
+      userRecoverSendCode.mutate(value)
+    }
     SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
     timer[label].startTimer()
   }
 
-  const handleCodeVerify = async (
-    label: 'email' | 'phoneNumber',
-    verifyData: UserEmailVerify | UserPhoneVerify
+  const handleCodeVerify = async <L extends labelType>(
+    label: L,
+    verifyData: VerifyDataMap[L]
   ) => {
     if (label === 'email') {
       const data: UserEmailVerify = verifyData as UserEmailVerify
@@ -79,6 +99,10 @@ function useVerificationCode() {
         verificationCode: verificationCode,
       }
       phoneVerify.mutate(data)
+    }
+    if (label === 'userRecover') {
+      const { email, verificationCode } = verifyData as UserRecoverVerifyBody
+      userRecoverVerify.mutate({ email, verificationCode })
     }
     SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
     SetIsCodeSent((prev) => ({ ...prev, [label]: false }))

--- a/src/types/api-request-types/user-recover-request-types.ts
+++ b/src/types/api-request-types/user-recover-request-types.ts
@@ -1,8 +1,8 @@
-export interface userRecoverVerifyBody {
+export interface UserRecoverVerifyBody {
   email: string
   verificationCode: string
 }
 
-export interface userRecoverSendBody {
+export interface UserRecoverSendBody {
   email: string
 }


### PR DESCRIPTION
## 🚀 PR 요약

> useVerificationCode에 탈퇴 회원 복구 로직 추가

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] refactor: 코드 리팩토링


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- useverificationcode에 탈퇴 회원 복구 로직 추가
- handleCodeVerify에 제네릭을 통한 type narrowing

### 참고 사항

- 서영님 코드에 덧붙힌 코드인데 컨벤션이나 동작 방식이 의도한 방향대로 작성되었는지 체크 부탁드립니다!

### 스크린 샷
- handleCodeVerify에 제네릭을 통한 type narrowing

<img width="791" height="183" alt="Screenshot 2025-09-25 at 11 52 06 AM" src="https://github.com/user-attachments/assets/098ae1e2-4af5-4829-b04f-a75bd6e24375" />

## 🔗 연관된 이슈

> closes #221
