### PR TITLE
Refactor: 로그인 관련 msw 수정 및 api 적용

### DIFF
--- a/src/components/auth/user-recover-modal/UserRecoverNoticeModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverNoticeModal.tsx
@@ -8,6 +8,7 @@ import {
   ModalMain,
   type ModalContextValue,
 } from '@/components/common/Modal'
+import { useWithdrawalDateStore } from '@/store'
 import { MehIcon } from 'lucide-react'
 
 interface UserRecoverNoticeModalProps {
@@ -19,6 +20,8 @@ export default function UserRecoverNoticeModal({
   userRecoverNoticeModalControl,
   userRecoverFormOpen,
 }: UserRecoverNoticeModalProps) {
+  const { withdrawalDate } = useWithdrawalDateStore()
+
   return (
     <Modal externalModalControl={userRecoverNoticeModalControl}>
       <ModalContent className="w-[90%] max-w-lg">
@@ -32,7 +35,7 @@ export default function UserRecoverNoticeModal({
           </h1>
           <div>
             <p className="text-center text-gray-600">
-              2025년 9월 20일 이후, 계정 정보는 완전히 삭제돼요.
+              {withdrawalDate} 이후, 계정 정보는 완전히 삭제돼요.
             </p>
             <p className="text-center text-gray-600">
               계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import { useToast } from '@/hooks'
 import { useLoginStore } from '@/store/useLoginStore'
 import type { UserLogin } from '@/types/api-request-types/auth-request-types'
@@ -25,7 +25,7 @@ export default function useLogin(
     mutationKey: ['auth', 'email', 'login'],
     mutationFn: async (payload) => {
       const response = await api.post(
-        `${MSW_BASE_URL}/auth/email/login`,
+        `${API_BASE_URL}/auth/email/login`,
         payload
       )
       const newAccessToken = response.data.access

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -9,17 +9,18 @@ import {
   useQueryClient,
   type UseMutationOptions,
 } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 import { useNavigate } from 'react-router'
 
 export default function useLogin(
-  options?: UseMutationOptions<string, Error, UserLogin>
+  options?: UseMutationOptions<string, AxiosError, UserLogin>
 ) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
   const { setIsLoggedIn } = useLoginStore()
   const navigate = useNavigate()
 
-  return useMutation<string, Error, UserLogin>({
+  return useMutation<string, AxiosError, UserLogin>({
     ...options,
     mutationKey: ['auth', 'email', 'login'],
     mutationFn: async (payload) => {
@@ -27,7 +28,7 @@ export default function useLogin(
         `${MSW_BASE_URL}/auth/email/login`,
         payload
       )
-      const newAccessToken = response.data.access_token
+      const newAccessToken = response.data.access
       return newAccessToken
     },
     onSuccess: async (newAccessToken: string) => {
@@ -37,8 +38,16 @@ export default function useLogin(
       triggerToast('success', 'Login 🎉', '로그인이 완료되었습니다.')
       navigate('/')
     },
-    onError: () => {
-      triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다.')
+    onError: (error) => {
+      const status = error.status
+
+      if (status === 400) {
+        triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다')
+      } else if (status === 401) {
+        triggerToast('warning', '탈퇴 예정 회원입니다')
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
     },
   })
 }

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -17,7 +17,7 @@ export default function useLogout(options?: UseMutationOptions) {
   return useMutation({
     mutationKey: ['users', 'logout'],
     mutationFn: async () => {
-      await api.post(`${MSW_BASE_URL}/users/logout`)
+      await api.post(`${MSW_BASE_URL}/auth/logout`)
     },
     onSuccess: () => {
       setIsLoggedIn(false)

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import { useToast } from '@/hooks'
 import { useLoginStore } from '@/store/useLoginStore'
 import { clearAccessToken } from '@/utils'
@@ -17,7 +17,7 @@ export default function useLogout(options?: UseMutationOptions) {
   return useMutation({
     mutationKey: ['users', 'logout'],
     mutationFn: async () => {
-      await api.post(`${MSW_BASE_URL}/auth/logout`)
+      await api.post(`${API_BASE_URL}/auth/logout`)
     },
     onSuccess: () => {
       setIsLoggedIn(false)

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -17,7 +17,7 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
     mutationKey: ['token', 'refresh'],
     mutationFn: async () => {
       const response = await api.post(`${MSW_BASE_URL}/auth/refresh`)
-      const newAccessToken = response.data.access_token
+      const newAccessToken = response.data.access
       return newAccessToken
     },
     onSuccess: (newAccessToken: string) => {

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import { useLoginStore } from '@/store/useLoginStore'
 import { setAccessToken } from '@/utils'
 import api from '@/utils/axios'
@@ -16,7 +16,7 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
     ...options,
     mutationKey: ['token', 'refresh'],
     mutationFn: async () => {
-      const response = await api.post(`${MSW_BASE_URL}/auth/refresh`)
+      const response = await api.post(`${API_BASE_URL}/auth/refresh`)
       const newAccessToken = response.data.access
       return newAccessToken
     },

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -1,7 +1,6 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
 import { http, HttpResponse, passthrough } from 'msw'
 import { userInformationMock } from '@/mocks/data/user-information-data'
-import { loginSchema } from '@/schemas/form-schema/login-schema'
 const ACCESS_TOKEN = `msw-access-token=access-token-test; Path=/; SameSite=Strict;`
 const REFRESH_TOKEN =
   'msw-refresh-token=refresh-token-test; Path=/; SameSite=Strict;'
@@ -10,45 +9,33 @@ const REFRESH_TOKEN =
 const login = http.post(
   `${MSW_BASE_URL}/auth/email/login`,
   async ({ request }) => {
-    const body = await request.json()
-    const parsedBody = loginSchema.safeParse(body)
+    const body = await request.clone().json()
 
-    if (!parsedBody.success) {
+    if (!body.email || !body.password) {
       return HttpResponse.json(
         {
-          error: 'Invalid credentials.',
+          error: '잘못된 입력 형식입니다',
         },
         { status: 400 }
       )
     }
 
-    const data = parsedBody.data
-
-    if (data.email === 'qwerty@test.com' && data.password === 'Qwer1234!!') {
-      return HttpResponse.json(
-        {
-          detail: 'Login successful',
-          access_token: `${ACCESS_TOKEN} Max-Age=10`,
-        },
-        {
-          status: 200,
-          headers: { 'Set-Cookie': `${REFRESH_TOKEN} Max-Age=360000` },
-        }
-      )
-    } else {
-      return HttpResponse.json(
-        {
-          error: 'Invalid credentials.',
-        },
-        { status: 400 }
-      )
-    }
+    return HttpResponse.json(
+      {
+        detail: '로그인이 완료되었습니다',
+        access: `${ACCESS_TOKEN} Max-Age=10`,
+      },
+      {
+        status: 200,
+        headers: { 'Set-Cookie': `${REFRESH_TOKEN} Max-Age=360000` },
+      }
+    )
   }
 )
 
-const logout = http.post(`${MSW_BASE_URL}/users/logout`, () => {
+const logout = http.post(`${MSW_BASE_URL}/auth/logout`, () => {
   return HttpResponse.json(
-    { detail: 'Logout successful' },
+    { detail: '로그아웃이 완료되었습니다' },
     {
       status: 200,
       headers: { 'Set-Cookie': `${REFRESH_TOKEN} Max-Age=0` },
@@ -61,9 +48,7 @@ const getUserInformation = http.get(
   `${MSW_BASE_URL}/users/me`,
   ({ request }) => {
     const header = request.headers.get('Authorization')
-    const hasBearerToken = header
-      ?.substring(7)
-      .includes('msw-access-token=access-token-test;')
+    const hasBearerToken = header?.includes('access')
 
     if (!hasBearerToken) {
       return HttpResponse.json(
@@ -75,6 +60,7 @@ const getUserInformation = http.get(
   }
 )
 
+// 액세스 토큰 재발급
 const getRefreshToken = http.post(`${MSW_BASE_URL}/auth/refresh`, () => {
   const currentCookie = document.cookie
   const isRefreshTokenRemain = currentCookie.includes('msw-refresh-token')
@@ -89,7 +75,7 @@ const getRefreshToken = http.post(`${MSW_BASE_URL}/auth/refresh`, () => {
   return HttpResponse.json(
     {
       detail: '새로운 액세스 토큰을 발급했습니다',
-      access_token: `${ACCESS_TOKEN} Max-Age=10`,
+      access: `${ACCESS_TOKEN} Max-Age=10`,
     },
     {
       status: 200,

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -48,7 +48,7 @@ const getUserInformation = http.get(
   `${MSW_BASE_URL}/users/me`,
   ({ request }) => {
     const header = request.headers.get('Authorization')
-    const hasBearerToken = header?.includes('access')
+    const hasBearerToken = header?.includes('Bearer')
 
     if (!hasBearerToken) {
       return HttpResponse.json(

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -23,6 +23,12 @@ import {
   InputFieldRowStyle,
   InputGroupStyle,
 } from '@/constants/auth-variants'
+import { UserRecoverModal } from '@/components/auth/user-recover-modal'
+import type { ModalContextValue } from '@/components/common/Modal'
+import { useState } from 'react'
+import type { AxiosError } from 'axios'
+import type { LoginErrorResponse } from '@/types/api-response-types/auth-response-types'
+import { useWithdrawalDateStore } from '@/store'
 
 function Login() {
   const {
@@ -34,10 +40,35 @@ function Login() {
     resolver: zodResolver(loginSchema),
   })
   const login = useLogin()
+  const { setWithdrawalDate } = useWithdrawalDateStore()
+  const [isUserRecoverModalOpen, setIsUserRecoverModalOpen] = useState(false)
+
+  const userRecoverFormModalControl: ModalContextValue = {
+    isOpen: isUserRecoverModalOpen,
+    open: () => {
+      setIsUserRecoverModalOpen(true)
+    },
+    close: () => {
+      setIsUserRecoverModalOpen(false)
+    },
+    toggle: () => {
+      setIsUserRecoverModalOpen((prev) => !prev)
+    },
+  }
 
   const onSubmit = async (data: LoginSchemaType) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    login.mutate(data)
+    try {
+      await login.mutateAsync(data)
+    } catch (error) {
+      const axiosError = error as AxiosError<LoginErrorResponse>
+      const status = axiosError.response?.status
+
+      if (status === 401) {
+        const dueDate = axiosError.response?.data?.due_date ?? null
+        setWithdrawalDate(dueDate ?? null)
+        userRecoverFormModalControl.open()
+      }
+    }
   }
 
   return (
@@ -84,6 +115,7 @@ function Login() {
           일반회원 로그인
         </AuthSubmitButton>
       </form>
+      <UserRecoverModal userRecoverModalControl={userRecoverFormModalControl} />
     </AuthContainer>
   )
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,5 +2,11 @@
 import { useToastStore } from '@/store/useToastStore'
 import { useNotificationNavigationItemStore } from '@/store/useNotificationNavigationItemStore'
 import { useChatRoomStore } from '@/store/useChatRoomStore'
+import { useWithdrawalDateStore } from './useWithdrawalDateStore'
 
-export { useToastStore, useNotificationNavigationItemStore, useChatRoomStore }
+export {
+  useToastStore,
+  useNotificationNavigationItemStore,
+  useChatRoomStore,
+  useWithdrawalDateStore,
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@
 import { useToastStore } from '@/store/useToastStore'
 import { useNotificationNavigationItemStore } from '@/store/useNotificationNavigationItemStore'
 import { useChatRoomStore } from '@/store/useChatRoomStore'
-import { useWithdrawalDateStore } from './useWithdrawalDateStore'
+import { useWithdrawalDateStore } from '@/store/useWithdrawalDateStore'
 
 export {
   useToastStore,

--- a/src/store/useWithdrawalDateStore.ts
+++ b/src/store/useWithdrawalDateStore.ts
@@ -1,0 +1,16 @@
+import { formattedDateWithKorean } from '@/utils/formatted-dates'
+import { create } from 'zustand'
+
+interface WithdrawalDateStore {
+  withdrawalDate: string | null
+  setWithdrawalDate: (value: string | null) => void
+}
+
+export const useWithdrawalDateStore = create<WithdrawalDateStore>((set) => ({
+  withdrawalDate: null,
+  setWithdrawalDate: (newValue) =>
+    set(() => {
+      if (!newValue) return { withdrawalDate: null }
+      return { withdrawalDate: formattedDateWithKorean(newValue) }
+    }),
+}))

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -9,3 +9,5 @@ export interface UserInformation {
   profileImageUrl?: string
   createdAt: Date
 }
+
+export type LoginErrorResponse = { due_date?: string | null }

--- a/src/utils/formatted-dates.ts
+++ b/src/utils/formatted-dates.ts
@@ -32,17 +32,28 @@ export const formattedEndDate = (endDateString: Date) => {
 }
 
 export const formattedDateWithDots = (date: string) => {
-  const yyyy = date?.substring(0, 4)
-  const mm = date?.substring(5, 7)
-  const dd = date?.substring(8, 10)
+  const dateWithNumber = date.replace(/\D/g, '')
+  const yyyy = dateWithNumber.substring(0, 4)
+  const mm = dateWithNumber.substring(4, 6)
+  const dd = dateWithNumber.substring(6, 8)
 
   return `${yyyy}. ${mm}. ${dd}.`
 }
 
 export const formattedDateWithHyphen = (date: string) => {
-  const yyyy = date?.substring(0, 4)
-  const mm = date?.substring(4, 6)
-  const dd = date?.substring(6, 8)
+  const dateWithNumber = date.replace(/\D/g, '')
+  const yyyy = dateWithNumber.substring(0, 4)
+  const mm = dateWithNumber.substring(4, 6)
+  const dd = dateWithNumber.substring(6, 8)
 
   return `${yyyy}-${mm}-${dd}`
+}
+
+export const formattedDateWithKorean = (date: string) => {
+  const dateWithNumber = date.replace(/\D/g, '')
+  const yyyy = dateWithNumber.substring(0, 4)
+  const mm = dateWithNumber.substring(4, 6)
+  const dd = dateWithNumber.substring(6, 8)
+
+  return `${yyyy}년 ${mm}월 ${dd}일`
 }

--- a/src/utils/manage-token.ts
+++ b/src/utils/manage-token.ts
@@ -1,11 +1,11 @@
 export function getAccessToken() {
-  return localStorage.getItem('access-token')
+  return localStorage.getItem('access')
 }
 
 export function setAccessToken(token: string) {
-  localStorage.setItem('access-token', token)
+  localStorage.setItem('access', token)
 }
 
 export function clearAccessToken() {
-  localStorage.removeItem('access-token')
+  localStorage.removeItem('access')
 }


### PR DESCRIPTION
## 🚀 PR 요약

로그인, 로그아웃, 토큰 재발급 msw 로직을 수정하고, base url을 api 전용으로 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그인, 로그아웃, 토큰 재발급 관련 로직들에서 response body의 `access_token` 데이터 명을 `access`로 수정
- 로그인 시 에러 status 코드에 따라 각각 다른 토스트 메시지 띄우도록 수정
- 회원 탈퇴 예정 날짜(due_date)를 저장하는 전역 상태 추가 (`useWithdrawalDateStore`)

### 참고 사항

- 로그인 시 탈퇴 회원일 경우 **401** 에러가 발생합니다.
- 서버에서 전달되는 `due_date`는 탈퇴 회원의 계정 삭제 예정 날짜입니다.
  (2025년 9월 25일에 탈퇴 신청하면 `due_date`는 2025-10-09)
- 회원 탈퇴 예정 날짜를 전역 상태로 관리합니다. 
  - 로그인 시 **401** 에러 발생하면 `due_date` 값을 받아와 **0000년 00월 00일** 형태로 변환하여 저장합니다.
  - 회원 탈퇴 모달에 `withdrawalDate`를 적용하여 렌더링합니다.

### 스크린 샷

아래 두 스크린 샷 모두 msw 적용 상태에서 따로 테스트 진행했고, 현재 push한 코드에는 **API_BASE_URL**이 적용되어 있습니다.

**정상 사용자(탈퇴 신청 X)가 로그인을 시도했을 때**
![StudyHub-Chrome2025-09-2513-57-08-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/332fd52a-ce63-45ca-9d41-e043b70e7e2c)

**탈퇴 회원이 로그인을 시도했을 때 (due_date는 임의로 2025-10-04로 설정)**
![StudyHub-Chrome2025-09-2513-56-07-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e57050e5-ea13-4f33-aa80-30d93f7c644d)

## 🔗 연관된 이슈

> closes #241 
