### PR TITLE
Fix: 메인 컨텐츠 최소 길이 설정

### DIFF
--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router'
 
 export default function AuthLayout() {
   return (
-    <div className="flex items-center justify-center bg-gray-50 py-0 sm:py-30">
+    <div className="flex items-center justify-center py-0 sm:py-30">
       <Outlet />
     </div>
   )

--- a/src/components/layout/MyPageLayout.tsx
+++ b/src/components/layout/MyPageLayout.tsx
@@ -8,7 +8,7 @@ export default function MyPageLayout() {
   const width = useWindowWidth()
 
   return (
-    <div className="flex flex-col items-center justify-start gap-8 bg-gray-100 p-8 md:flex-row md:items-start md:justify-center">
+    <div className="flex flex-col items-center justify-start gap-8 p-8 md:flex-row md:items-start md:justify-center">
       {width < MD_WIDTH_PIXEL ? <MobileMyPageNavBar /> : <MyPageSideBar />}
 
       <div className="min-h-[700px] max-w-4xl flex-1 rounded-lg border border-gray-200 bg-white p-8">

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,11 +1,35 @@
 import { Header, Footer, Chat } from '@/components'
+import { SM_WIDTH_PIXEL } from '@/constants/break-points'
+import { useWindowHeight, useWindowWidth } from '@/hooks'
 import { Outlet } from 'react-router'
 
+const HEADER_HEIGHT_PX = 64
+const DESKTOP_FOOTER_HEIGHT_PX = 313
+//모바일일 때 길이는 가변적이라 일단 임의의 값 할당
+const MOBILE_FOOTER_HEIGHT_PX = 745
+
 export default function RootLayout() {
+  const windowHeight = useWindowHeight()
+  const windowWidth = useWindowWidth()
+
+  const minContentHeight =
+    windowHeight -
+    HEADER_HEIGHT_PX -
+    (windowWidth >= SM_WIDTH_PIXEL
+      ? DESKTOP_FOOTER_HEIGHT_PX
+      : MOBILE_FOOTER_HEIGHT_PX)
+
   return (
     <div>
       <Header />
-      <Outlet />
+      <div
+        style={{
+          minHeight: `${minContentHeight}px`,
+        }}
+        className="bg-gray-100"
+      >
+        <Outlet />
+      </div>
       <Footer />
       <Chat />
     </div>


### PR DESCRIPTION
## 🚀 PR 요약

> 메인 컨텐츠 최소 길이 설정

## ✏️ 변경 유형

- [x] fix: 버그 수정


## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 메인 컨텐츠 최소 길이 설정
- 하위 레이아웃 배경색 통일

### 참고 사항

- TODO: 모바일 footer 길이를 다이나믹하게 측정해서 최소 길이 설정

### 스크린 샷
+ 이전

<img width="500"  alt="Image" src="https://github.com/user-attachments/assets/a190d581-3bfb-4e70-b56f-e2e137c7fc9d" />

<img width="500" alt="Screenshot 2025-09-25 at 2 37 38 PM" src="https://github.com/user-attachments/assets/33106921-3c9a-4305-b6d0-d58275917cb7" />

+ 이후
<img width="500" alt="Screenshot 2025-09-25 at 2 53 13 PM" src="https://github.com/user-attachments/assets/a5d0d56a-b796-4722-ba12-1bef530c03bf" />

<img width="500"  alt="Screenshot 2025-09-25 at 2 53 00 PM" src="https://github.com/user-attachments/assets/4d394f8f-1f23-415a-8779-42a12e04115d" />


## 🔗 연관된 이슈

> closes #246
