### PR TITLE
Refactor: React Query 에러 처리 로직 수정

### DIFF
--- a/src/hooks/api/auth/useEmailSendCode.ts
+++ b/src/hooks/api/auth/useEmailSendCode.ts
@@ -3,14 +3,14 @@ import useToast from '@/hooks/useToast'
 import type { UserEmailSendCode } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function useEmailSendCode(
-  options?: UseMutationOptions<unknown, AxiosError, UserEmailSendCode>
+  options?: UseMutationOptions<unknown, Error, UserEmailSendCode>
 ) {
   const { triggerToast } = useToast()
 
-  return useMutation<unknown, AxiosError, UserEmailSendCode>({
+  return useMutation<unknown, Error, UserEmailSendCode>({
     ...options,
     mutationKey: ['auth', 'email', 'send-code'],
     mutationFn: async ({ email }) => {
@@ -24,10 +24,13 @@ export default function useEmailSendCode(
       )
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못된 이메일 형식입니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 이메일 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/hooks/api/auth/useEmailVerify.ts
+++ b/src/hooks/api/auth/useEmailVerify.ts
@@ -3,14 +3,14 @@ import useToast from '@/hooks/useToast'
 import type { UserEmailVerify } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function useEmailVerify(
-  options?: UseMutationOptions<unknown, AxiosError, UserEmailVerify>
+  options?: UseMutationOptions<unknown, Error, UserEmailVerify>
 ) {
   const { triggerToast } = useToast()
 
-  return useMutation<unknown, AxiosError, UserEmailVerify>({
+  return useMutation<unknown, Error, UserEmailVerify>({
     ...options,
     mutationKey: ['auth', 'email', 'verify'],
     mutationFn: async ({ email, verificationCode }) => {
@@ -23,10 +23,13 @@ export default function useEmailVerify(
       triggerToast('success', '인증 완료 ✅', '다음 단계를 진행해주세요')
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못된 인증코드 형식입니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -9,18 +9,18 @@ import {
   useQueryClient,
   type UseMutationOptions,
 } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 import { useNavigate } from 'react-router'
 
 export default function useLogin(
-  options?: UseMutationOptions<string, AxiosError, UserLogin>
+  options?: UseMutationOptions<string, Error, UserLogin>
 ) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
   const { setIsLoggedIn } = useLoginStore()
   const navigate = useNavigate()
 
-  return useMutation<string, AxiosError, UserLogin>({
+  return useMutation<string, Error, UserLogin>({
     ...options,
     mutationKey: ['auth', 'email', 'login'],
     mutationFn: async (payload) => {
@@ -39,12 +39,15 @@ export default function useLogin(
       navigate('/')
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다')
-      } else if (status === 401) {
-        triggerToast('warning', '탈퇴 예정 회원입니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다')
+        } else if (status === 401) {
+          triggerToast('warning', '탈퇴 예정 회원입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/hooks/api/auth/usePhoneSendCode.ts
+++ b/src/hooks/api/auth/usePhoneSendCode.ts
@@ -3,14 +3,14 @@ import useToast from '@/hooks/useToast'
 import type { UserPhoneSendCode } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function usePhoneSendCode(
-  options?: UseMutationOptions<unknown, AxiosError, UserPhoneSendCode>
+  options?: UseMutationOptions<unknown, Error, UserPhoneSendCode>
 ) {
   const { triggerToast } = useToast()
 
-  return useMutation<unknown, AxiosError, UserPhoneSendCode>({
+  return useMutation<unknown, Error, UserPhoneSendCode>({
     ...options,
     mutationKey: ['auth', 'phone', 'send-code'],
     mutationFn: async ({ phoneNumber }) => {
@@ -26,10 +26,13 @@ export default function usePhoneSendCode(
       )
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못된 휴대전화 번호 형식입니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 휴대전화 번호 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/hooks/api/auth/usePhoneVerify.ts
+++ b/src/hooks/api/auth/usePhoneVerify.ts
@@ -3,14 +3,14 @@ import useToast from '@/hooks/useToast'
 import type { UserPhoneVerify } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function usePhoneVerify(
-  options?: UseMutationOptions<unknown, AxiosError, UserPhoneVerify>
+  options?: UseMutationOptions<unknown, Error, UserPhoneVerify>
 ) {
   const { triggerToast } = useToast()
 
-  return useMutation<unknown, AxiosError, UserPhoneVerify>({
+  return useMutation<unknown, Error, UserPhoneVerify>({
     ...options,
     mutationKey: ['auth', 'phone', 'verify'],
     mutationFn: async ({ phoneNumber, verificationCode }) => {
@@ -23,10 +23,13 @@ export default function usePhoneVerify(
       triggerToast('success', '인증 완료 ✅', '다음 단계를 진행해주세요')
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못된 인증코드 형식입니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -3,14 +3,14 @@ import useToast from '@/hooks/useToast'
 import type { UserSignup } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
-import type { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function useSignup(
-  options?: UseMutationOptions<unknown, AxiosError, UserSignup>
+  options?: UseMutationOptions<unknown, Error, UserSignup>
 ) {
   const { triggerToast } = useToast()
 
-  return useMutation<unknown, AxiosError, UserSignup>({
+  return useMutation<unknown, Error, UserSignup>({
     ...options,
     mutationKey: ['auth', 'email', 'signup'],
     mutationFn: async ({
@@ -30,10 +30,13 @@ export default function useSignup(
       triggerToast('success', 'Signup ✨', '회원가입을 완료했습니다')
     },
     onError: (error) => {
-      const status = error.status
-
-      if (status === 400) {
-        triggerToast('error', '잘못 입력된 항목이 있습니다')
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못 입력된 항목이 있습니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
       } else {
         triggerToast('error', '잠시 후 다시 시도해주세요')
       }

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -26,8 +26,7 @@ import {
 import { UserRecoverModal } from '@/components/auth/user-recover-modal'
 import type { ModalContextValue } from '@/components/common/Modal'
 import { useState } from 'react'
-import type { AxiosError } from 'axios'
-import type { LoginErrorResponse } from '@/types/api-response-types/auth-response-types'
+import { AxiosError } from 'axios'
 import { useWithdrawalDateStore } from '@/store'
 
 function Login() {
@@ -60,13 +59,13 @@ function Login() {
     try {
       await login.mutateAsync(data)
     } catch (error) {
-      const axiosError = error as AxiosError<LoginErrorResponse>
-      const status = axiosError.response?.status
-
-      if (status === 401) {
-        const dueDate = axiosError.response?.data?.due_date ?? null
-        setWithdrawalDate(dueDate ?? null)
-        userRecoverFormModalControl.open()
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 401) {
+          const dueDate = error.response?.data?.due_date ?? null
+          setWithdrawalDate(dueDate ?? null)
+          userRecoverFormModalControl.open()
+        }
       }
     }
   }


### PR DESCRIPTION
## 🚀 PR 요약

Auth 관련 React Query Hooks의 에러 처리 로직을 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- React Query hook 내에서 바로 `AxiosError` 타입으로 처리해버리지 않고, `if else` 조건문으로 안전하게 처리하도록 수정했습니다.

### 참고 사항

- 작업 진행하며 알게 된 로그인 이슈(가입하지 않은 회원이 로그인 시도하면 탈퇴 예정 회원 알림 발생), 회원가입 이슈(인증코드 관련 UX 개선) 등은 따로 issue 파서 수정 진행하도록 하겠습니다!

## 🔗 연관된 이슈

> closes #249
