### PR TITLE
Fix: 가입하지 않은 사용자 로그인 시도 버그 수정

### DIFF
--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -41,10 +41,19 @@ export default function useLogin(
     onError: (error) => {
       if (error instanceof AxiosError) {
         const status = error.status
+        const dueDate = error.response?.data?.due_date
         if (status === 400) {
           triggerToast('error', '잘못된 이메일 또는 비밀번호 입니다')
         } else if (status === 401) {
-          triggerToast('warning', '탈퇴 예정 회원입니다')
+          if (dueDate) {
+            triggerToast('warning', '탈퇴 예정 회원입니다')
+          } else {
+            triggerToast(
+              'error',
+              'Login Failed 😥',
+              '이메일 또는 비밀번호가 올바르지 않습니다'
+            )
+          }
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -61,9 +61,9 @@ function Login() {
     } catch (error) {
       if (error instanceof AxiosError) {
         const status = error.status
-        if (status === 401) {
-          const dueDate = error.response?.data?.due_date ?? null
-          setWithdrawalDate(dueDate ?? null)
+        const dueDate = error.response?.data?.due_date
+        if (status === 401 && dueDate) {
+          setWithdrawalDate(dueDate)
           userRecoverFormModalControl.open()
         }
       }


### PR DESCRIPTION
## 🚀 PR 요약

회원가입하지 않은 사용자가 로그인 시도 시 탈퇴 회원 복구 모달을 띄우고 탈퇴 예정 회원이라는 토스트 메시지 알림을 띄우는 버그를 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그인 page: 401 에러 발생과 동시에 **response data**에 `due_date` 값이 존재할 때만 탈퇴 회원 복구 모달 렌더링
- `useLogin`: 401 에러 발생 시 **response data**에 `due_date` 값이 존재하는 지 안 하는 지에 따라 각각 다른 토스트 메시지 알림 렌더링

### 스크린 샷

**가입하지 않은 이메일, 비밀번호로 로그인 시도 테스트**
![StudyHub-Chrome2025-09-2516-49-30-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cbca5712-07b6-43b7-a977-aaf30880d6bd)

## 🔗 연관된 이슈

> closes #256 
