### PR TITLE
Design: 토스트 메시지 반응형 UI 추가

### DIFF
--- a/src/components/common/toast/ToastContainer.tsx
+++ b/src/components/common/toast/ToastContainer.tsx
@@ -3,18 +3,24 @@ import ToastItem from './ToastItem'
 import { useEffect, useState } from 'react'
 import { useDebounce } from '@/hooks/useDebounce'
 import type { Toast } from '@/types'
+import { useWindowWidth } from '@/hooks'
 
 function ToastContainer() {
   const [renderedToasts, setRenderedToasts] = useState<Toast[]>([])
   const { toasts } = useToastStore()
   const debouncedToasts = useDebounce(toasts, 200)
+  const windowWidth = useWindowWidth()
+  const mobileToastContainerWidth = windowWidth - 8
 
   useEffect(() => {
     setRenderedToasts(debouncedToasts)
   }, [debouncedToasts])
 
   return (
-    <div className="fixed top-18 right-1 z-100 w-112 space-y-1">
+    <div
+      className="fixed top-18 right-1 z-100 space-y-1"
+      style={{ width: windowWidth < 450 ? mobileToastContainerWidth : '448px' }}
+    >
       {renderedToasts.map(({ id, type, title, content }) => (
         <ToastItem
           key={id}

--- a/src/components/common/toast/ToastContainer.tsx
+++ b/src/components/common/toast/ToastContainer.tsx
@@ -5,12 +5,16 @@ import { useDebounce } from '@/hooks/useDebounce'
 import type { Toast } from '@/types'
 import { useWindowWidth } from '@/hooks'
 
+const TOAST_DEBOUNCE_DELAY = 200
+const TOAST_MOBILE_WINDOW_WIDTH = 450
+const TOAST_MOBILE_PADDING = 8
+
 function ToastContainer() {
   const [renderedToasts, setRenderedToasts] = useState<Toast[]>([])
   const { toasts } = useToastStore()
-  const debouncedToasts = useDebounce(toasts, 200)
+  const debouncedToasts = useDebounce(toasts, TOAST_DEBOUNCE_DELAY)
   const windowWidth = useWindowWidth()
-  const mobileToastContainerWidth = windowWidth - 8
+  const mobileToastContainerWidth = windowWidth - TOAST_MOBILE_PADDING
 
   useEffect(() => {
     setRenderedToasts(debouncedToasts)
@@ -19,7 +23,12 @@ function ToastContainer() {
   return (
     <div
       className="fixed top-18 right-1 z-100 space-y-1"
-      style={{ width: windowWidth < 450 ? mobileToastContainerWidth : '448px' }}
+      style={{
+        width:
+          windowWidth < TOAST_MOBILE_WINDOW_WIDTH
+            ? mobileToastContainerWidth
+            : '448px',
+      }}
     >
       {renderedToasts.map(({ id, type, title, content }) => (
         <ToastItem

--- a/src/components/common/toast/ToastItem.tsx
+++ b/src/components/common/toast/ToastItem.tsx
@@ -56,7 +56,7 @@ function ToastItem({
   return (
     <div
       className={cn(
-        'animate-fade-in-out-toast flex justify-between gap-3 rounded-lg border border-solid p-[17px] opacity-0',
+        'animate-fade-in-out-toast flex justify-between gap-3 rounded-lg border border-solid p-4 opacity-0',
         styles.border,
         styles.bg
       )}


### PR DESCRIPTION
## 🚀 PR 요약

토스트 메시지 컴포넌트에 반응형 UI를 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useWindowWidth`를 이용해 브라우저 width를 계산 후, **450px 이상**에서는 기존 레이아웃을 그대로 사용하고 **450px 미만**에서는 좌우 여백을 제외한 화면 너비를 전부 사용해 컴포넌트를 꽉 차게 표시합니다.

### 스크린 샷

**화면 사이즈별 UI 테스트**
![StudyHub-Chrome2025-09-2517-36-45-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3519c5b6-5768-451b-bae1-df8f2dbe34d0)

**iPhone SE 화면**
<img width="262" height="453" alt="image" src="https://github.com/user-attachments/assets/928dbcaa-ae15-400f-a67c-d5870d034357" />

**Galaxy S20 Ultra 화면**
<img width="208" height="450" alt="image" src="https://github.com/user-attachments/assets/7e53492b-a488-4e7a-a5b8-8a334c3ff5b0" />


## 🔗 연관된 이슈

> closes #259 
