### PR TITLE
Fix: 회원가입 page 인증코드 버그 수정 및 UX 개선

### DIFF
--- a/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
+++ b/src/components/auth/user-recover-modal/UserRecoverFormModal.tsx
@@ -15,6 +15,7 @@ import {
   UserRecoverSchema,
   type UserRecover,
 } from '@/schemas/form-schema/user-recover-schema'
+import { cn } from '@/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { RotateCwIcon } from 'lucide-react'
 import { useForm } from 'react-hook-form'
@@ -95,8 +96,12 @@ export default function UserRecoverFormModal({
             </div>
             <div className="flex w-full gap-2">
               <Input
+                disabled={!isCodeSent.userRecover}
                 placeholder="인증번호를 입력해주세요."
-                className="flex-1"
+                className={cn(
+                  isCodeVerified.userRecover &&
+                    'flex-1 disabled:bg-white disabled:text-black'
+                )}
                 {...register('verificationCode')}
               />
               <AuthVerifyButton

--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -14,6 +14,7 @@ import {
   type InfoUpdateType,
 } from '@/schemas/form-schema/info-update-schema'
 import { useVerificationCode } from '@/hooks'
+import { cn } from '@/utils'
 
 export const InfoUpdateForm = () => {
   const { data: userInfo } = useUserInformation()
@@ -147,10 +148,15 @@ export const InfoUpdateForm = () => {
           <div className="flex flex-col gap-2">
             <div className="flex gap-2">
               <Input
+                disabled={!isCodeSent.phoneNumber}
                 id="infoUpdateVerificationCode"
                 {...register('infoUpdateVerificationCode')}
                 placeholder="인증코드 6자리 입력"
                 readOnly={isCodeVerified.phoneNumber}
+                className={cn(
+                  isCodeVerified.phoneNumber &&
+                    'disabled:bg-white disabled:text-black'
+                )}
               />
               <Button
                 variant={isCodeVerified.phoneNumber ? 'secondary' : 'primary'}

--- a/src/constants/input-variants.ts
+++ b/src/constants/input-variants.ts
@@ -1,5 +1,5 @@
 export const InputBase =
-  'w-full focus:ring-primary-500 rounded-lg py-[13px] text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2' as const
+  'w-full focus:ring-primary-500 rounded-lg py-3 text-sm ring ring-gray-300 outline-none placeholder:text-gray-400 focus:border-none focus:ring-2 disabled:bg-gray-50 disabled:text-gray-200 disabled:placeholder:text-gray-200 bg-white' as const
 
 export const InputError = {
   true: 'ring-danger-100',

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -70,15 +70,15 @@ function useVerificationCode() {
   const handleCodeSend = async (label: labelType, value: string) => {
     if (label === 'email') {
       const data: UserEmailSendCode = { email: value }
-      emailSendCode.mutate(data)
+      await emailSendCode.mutateAsync(data)
     }
     if (label === 'phoneNumber') {
       const phoneNumberE164KR = formattedPhoneToE164KR(value)
       const data: UserPhoneSendCode = { phoneNumber: phoneNumberE164KR }
-      phoneSendCode.mutate(data)
+      await phoneSendCode.mutateAsync(data)
     }
     if (label === 'userRecover') {
-      userRecoverSendCode.mutate(value)
+      await userRecoverSendCode.mutateAsync(value)
     }
     SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
     timer[label].startTimer()

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -90,7 +90,7 @@ function useVerificationCode() {
   ) => {
     if (label === 'email') {
       const data: UserEmailVerify = verifyData as UserEmailVerify
-      emailVerify.mutate(data)
+      await emailVerify.mutateAsync(data)
     }
     if (label === 'phoneNumber') {
       const { phoneNumber, verificationCode } = verifyData as UserPhoneVerify
@@ -98,11 +98,11 @@ function useVerificationCode() {
         phoneNumber: formattedPhoneToE164KR(phoneNumber),
         verificationCode: verificationCode,
       }
-      phoneVerify.mutate(data)
+      await phoneVerify.mutateAsync(data)
     }
     if (label === 'userRecover') {
       const { email, verificationCode } = verifyData as UserRecoverVerifyBody
-      userRecoverVerify.mutate({ email, verificationCode })
+      await userRecoverVerify.mutateAsync({ email, verificationCode })
     }
     SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
     SetIsCodeSent((prev) => ({ ...prev, [label]: false }))

--- a/src/index.css
+++ b/src/index.css
@@ -143,3 +143,19 @@ body {
     background-color: #f3f4f6;
   }
 }
+
+@layer base {
+  input:autofill,
+  input:autofill:hover,
+  input:autofill:focus,
+  input:autofill:active,
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-text-fill-color: theme(--color-black);
+    box-shadow: 0 0 0 1000px theme(--color-white) inset;
+    -webkit-box-shadow: 0 0 0 1000px theme(--color-white) inset;
+    transition: background-color 5000s ease-in-out 0s;
+  }
+}

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -189,8 +189,12 @@ function Signup() {
           )}
           <div className={InputFieldRowStyle}>
             <Input
+              disabled={!isCodeSent.email}
               {...register('verificationCode.email')}
               placeholder="인증코드 6자리를 입력해주세요"
+              className={cn(
+                isCodeVerified.email && 'disabled:bg-white disabled:text-black'
+              )}
             />
             <AuthVerifyButton
               disabled={!isCodeSent.email}
@@ -233,8 +237,13 @@ function Signup() {
           )}
           <div className={InputFieldRowStyle}>
             <Input
+              disabled={!isCodeSent.phoneNumber}
               {...register('verificationCode.phoneNumber')}
               placeholder="인증코드 6자리를 입력해주세요"
+              className={cn(
+                isCodeVerified.phoneNumber &&
+                  'disabled:bg-white disabled:text-black'
+              )}
             />
             <AuthVerifyButton
               disabled={!isCodeSent.phoneNumber}

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/schemas/form-schema/signup-schema'
 import { cn } from '@/utils'
 import { formattedDateWithHyphen } from '@/utils/formatted-dates'
+import { formattedPhoneToE164KR } from '@/utils/formatted-phone'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
@@ -59,7 +60,7 @@ function Signup() {
       name: data.name,
       nickname: data.nickname,
       birthday: formattedDateWithHyphen(data.birthday),
-      phoneNumber: data.phoneNumber,
+      phoneNumber: formattedPhoneToE164KR(data.phoneNumber),
       emailVerificationCode: data.verificationCode.email,
       phoneVerificationCode: data.verificationCode.phoneNumber,
       gender: data.gender,

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -18,7 +18,7 @@ import {
   InputFieldColStyle,
   InputFieldRowStyle,
 } from '@/constants/auth-variants'
-import { useToast, useVerificationCode } from '@/hooks'
+import { useVerificationCode } from '@/hooks'
 import useSignup from '@/hooks/api/auth/useSignup'
 import {
   signupSchema,
@@ -27,12 +27,10 @@ import {
 import { cn } from '@/utils'
 import { formattedDateWithHyphen } from '@/utils/formatted-dates'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
 function Signup() {
-  const [isDuplicateChecked, setIsDuplicateChecked] = useState(false)
   const {
     register,
     handleSubmit,
@@ -45,7 +43,6 @@ function Signup() {
     resolver: zodResolver(signupSchema),
   })
   const navigate = useNavigate()
-  const { triggerToast } = useToast()
   const {
     isCodeSent,
     isCodeVerified,
@@ -71,21 +68,9 @@ function Signup() {
     navigate('/auth/login')
   }
 
-  const isNicknameNotValid =
-    getFieldState('nickname').invalid || !watch('nickname')
   const isEmailNotValid = getFieldState('email').invalid || !watch('email')
   const isPhoneNumberNotValid =
     getFieldState('phoneNumber').invalid || !watch('phoneNumber')
-
-  const handleDuplicateCheck = async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    setIsDuplicateChecked(true)
-    triggerToast(
-      'success',
-      '사용 가능한 닉네임입니다.',
-      '다음 단계를 진행해 주세요'
-    )
-  }
 
   return (
     <AuthContainer className="flex flex-col gap-10">
@@ -113,12 +98,6 @@ function Signup() {
               {...register('nickname')}
               placeholder="닉네임을 입력해주세요"
             />
-            <AuthVerifyButton
-              disabled={isNicknameNotValid}
-              onClick={handleDuplicateCheck}
-            >
-              중복확인
-            </AuthVerifyButton>
           </div>
           {errors.nickname && (
             <InputErrorMessage>{`${errors.nickname.message}`}</InputErrorMessage>
@@ -293,7 +272,6 @@ function Signup() {
           disabled={
             !isValid ||
             isSubmitting ||
-            !isDuplicateChecked ||
             !isCodeVerified.email ||
             !isCodeVerified.phoneNumber
           }


### PR DESCRIPTION
## 🚀 PR 요약

회원가입 페이지에서 발생하는 인증코드 버그를 수정하고 그 외 몇 가지 UX 개선 사항을 적용했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

**버그 수정 사항**
- 인증코드 전송 에러 발생 시 타이머가 작동되지 않도록 수정
- 인증코드 검증 에러 발생 시 검증 로직이 초기화되지 않도록 수정

**UX 개선 사항**
- 인증코드 검증 `Input`에 `disabled` 속성 추가
- input 자동 입력 시 적용되는 `:autofill` 스타일 덮어쓰기

**그 외 수정 사항**
- 닉네임 중복 확인 버튼 및 관련 코드 삭제
- api 명세서에 맞게 휴대전화 데이터 형식 **+8210~** 형태로 변환

### 스크린 샷

**인증코드 전송 에러 발생 시 타이머 작동 X**
![StudyHub-Chrome2025-09-2612-37-45-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/21d9a047-63de-49d4-93ee-edc1b1f04632)

**인증코드 검증 에러 발생 시 검증 로직 초기화 X**
![StudyHub-Chrome2025-09-2612-42-09-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d1d3d000-335b-4876-9642-3b6508f3bc1e)

**input 자동 입력 시 기본 `:autofill` 스타일로 변화 X**
![StudyHub-Chrome2025-09-2613-47-21-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e2154b40-83e0-496d-aac0-849ec18951e2)

## 🔗 연관된 이슈

> closes #257
