### PR TITLE
Refactor: 회원가입 관련 api 중복 데이터 전송 시 에러 처리 추가

### DIFF
--- a/src/hooks/api/auth/useEmailSendCode.ts
+++ b/src/hooks/api/auth/useEmailSendCode.ts
@@ -28,6 +28,12 @@ export default function useEmailSendCode(
         const status = error.status
         if (status === 400) {
           triggerToast('error', '잘못된 이메일 형식입니다')
+        } else if (status === 409) {
+          triggerToast(
+            'error',
+            '이미 가입된 이메일입니다',
+            '다른 이메일을 사용해주세요'
+          )
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/hooks/api/auth/useEmailVerify.ts
+++ b/src/hooks/api/auth/useEmailVerify.ts
@@ -27,6 +27,12 @@ export default function useEmailVerify(
         const status = error.status
         if (status === 400) {
           triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else if (status === 409) {
+          triggerToast(
+            'error',
+            '이미 가입된 이메일입니다',
+            '다른 이메일을 사용해주세요'
+          )
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/hooks/api/auth/usePhoneSendCode.ts
+++ b/src/hooks/api/auth/usePhoneSendCode.ts
@@ -30,6 +30,12 @@ export default function usePhoneSendCode(
         const status = error.status
         if (status === 400) {
           triggerToast('error', '잘못된 휴대전화 번호 형식입니다')
+        } else if (status === 409) {
+          triggerToast(
+            'error',
+            '이미 가입된 휴대전화 번호입니다',
+            '다른 번호를 사용해주세요'
+          )
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/hooks/api/auth/usePhoneVerify.ts
+++ b/src/hooks/api/auth/usePhoneVerify.ts
@@ -27,6 +27,12 @@ export default function usePhoneVerify(
         const status = error.status
         if (status === 400) {
           triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else if (status === 409) {
+          triggerToast(
+            'error',
+            '이미 가입된 휴대전화 번호입니다',
+            '다른 번호를 사용해주세요'
+          )
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -34,6 +34,12 @@ export default function useSignup(
         const status = error.status
         if (status === 400) {
           triggerToast('error', '잘못 입력된 항목이 있습니다')
+        } else if (status === 409) {
+          triggerToast(
+            'error',
+            '이미 가입된 계정 정보입니다',
+            '다른 이메일 또는 휴대전화 번호를 사용해주세요'
+          )
         } else {
           triggerToast('error', '잠시 후 다시 시도해주세요')
         }

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -65,7 +65,7 @@ function Signup() {
       phoneVerificationCode: data.verificationCode.phoneNumber,
       gender: data.gender,
     }
-    signup.mutate(signupData)
+    await signup.mutateAsync(signupData)
     navigate('/auth/login')
   }
 


### PR DESCRIPTION
## 🚀 PR 요약

회원가입, 이메일 & 휴대전화 번호 인증코드 전송 & 검증 api에서 중복 데이터 전송 시 409 에러가 발생하면 전용 토스트 메시지 알림이 렌더링되도록 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 409 에러 발생 시 전용 토스트 메시지 알림 렌더링

### 스크린 샷

![StudyHub-Chrome2025-09-2620-36-08-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7aa90e98-c5f6-4ba8-b461-eac791b7ff2b)

## 🔗 연관된 이슈

> closes #264
