### PR TITLE
Feature: 카카오 소셜로그인 추가

### DIFF
--- a/src/constants/oauth-constants.ts
+++ b/src/constants/oauth-constants.ts
@@ -1,0 +1,5 @@
+export const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID
+
+export const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI
+
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`

--- a/src/hooks/api/auth/useKakaoCallback.ts
+++ b/src/hooks/api/auth/useKakaoCallback.ts
@@ -26,7 +26,7 @@ export default function useKakaoCallback(
       const response = await api.post(`${API_BASE_URL}/auth/kakao/callback`, {
         code: code,
       })
-      const newAccessToken = response.data.access
+      const newAccessToken = response.data.access_token
       return newAccessToken
     },
     onSuccess: async (newAccessToken: string) => {

--- a/src/hooks/api/auth/useKakaoCallback.ts
+++ b/src/hooks/api/auth/useKakaoCallback.ts
@@ -1,0 +1,48 @@
+import { API_BASE_URL } from '@/constants/url-constants'
+import { useToast } from '@/hooks'
+import { useLoginStore } from '@/store/useLoginStore'
+import type { UserKakaoLogin } from '@/types/api-request-types/auth-request-types'
+import { setAccessToken } from '@/utils'
+import api from '@/utils/axios'
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+
+export default function useKakaoCallback(
+  options?: UseMutationOptions<string, Error, UserKakaoLogin>
+) {
+  const qc = useQueryClient()
+  const { triggerToast } = useToast()
+  const { setIsLoggedIn } = useLoginStore()
+  const navigate = useNavigate()
+
+  return useMutation<string, Error, UserKakaoLogin>({
+    ...options,
+    mutationKey: ['auth', 'kakao', 'callback'],
+    mutationFn: async ({ code }) => {
+      const response = await api.post(`${API_BASE_URL}/auth/kakao/callback`, {
+        code: code,
+      })
+      const newAccessToken = response.data.access
+      return newAccessToken
+    },
+    onSuccess: async (newAccessToken: string) => {
+      setAccessToken(newAccessToken)
+      setIsLoggedIn(true)
+      await qc.invalidateQueries({ queryKey: ['users', 'me'] })
+      triggerToast(
+        'success',
+        'Kakao Login 🎉',
+        '카카오 로그인이 완료되었습니다.'
+      )
+      navigate('/')
+    },
+    onError: () => {
+      triggerToast('error', '잠시 후 다시 시도해주세요')
+      navigate('/auth/login')
+    },
+  })
+}

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -28,7 +28,7 @@ export default function useLogin(
         `${API_BASE_URL}/auth/email/login`,
         payload
       )
-      const newAccessToken = response.data.access
+      const newAccessToken = response.data.access_token
       return newAccessToken
     },
     onSuccess: async (newAccessToken: string) => {

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -17,7 +17,7 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
     mutationKey: ['token', 'refresh'],
     mutationFn: async () => {
       const response = await api.post(`${API_BASE_URL}/auth/refresh`)
-      const newAccessToken = response.data.access
+      const newAccessToken = response.data.access_token
       return newAccessToken
     },
     onSuccess: (newAccessToken: string) => {

--- a/src/pages/auth/KakaoAuth.tsx
+++ b/src/pages/auth/KakaoAuth.tsx
@@ -1,0 +1,20 @@
+import useKakaoCallback from '@/hooks/api/auth/useKakaoCallback'
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router'
+
+function KakaoAuth() {
+  const kakaoCallback = useKakaoCallback()
+  const [searchParams] = useSearchParams()
+  const code = searchParams.get('code')
+
+  useEffect(() => {
+    if (!code) return
+
+    kakaoCallback.mutate({ code })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code])
+
+  return <div>카카오 로그인 중...</div>
+}
+
+export default KakaoAuth

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -28,6 +28,7 @@ import type { ModalContextValue } from '@/components/common/Modal'
 import { useState } from 'react'
 import { AxiosError } from 'axios'
 import { useWithdrawalDateStore } from '@/store'
+import { KAKAO_AUTH_URL } from '@/constants/oauth-constants'
 
 function Login() {
   const {
@@ -70,6 +71,10 @@ function Login() {
     }
   }
 
+  const handleKakaoLogin = () => {
+    window.location.href = KAKAO_AUTH_URL
+  }
+
   return (
     <AuthContainer className="flex flex-col gap-10">
       <div className={InputFieldColStyle}>
@@ -81,7 +86,7 @@ function Login() {
       </div>
 
       <div className={InputGroupStyle}>
-        <AuthSocialLoginButton socialType="kakao" />
+        <AuthSocialLoginButton socialType="kakao" onClick={handleKakaoLogin} />
         <AuthSocialLoginButton socialType="naver" />
       </div>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { CompletedStudy } from '@/pages/my-page/CompletedStudy'
 import FindEmail from '@/pages/auth/FindEmail'
 import FindPassword from '@/pages/auth/FindPassword'
 import NotFound from '@/pages/NotFound'
+import KakaoAuth from '@/pages/auth/KakaoAuth'
 
 export {
   LandingPage,
@@ -20,4 +21,5 @@ export {
   FindEmail,
   FindPassword,
   NotFound,
+  KakaoAuth,
 }

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -11,6 +11,7 @@ import {
   FindPassword,
   NotFound,
 } from '@/pages'
+import KakaoAuth from '@/pages/auth/KakaoAuth'
 import { Route, Routes } from 'react-router'
 
 function MainRoutes() {
@@ -37,6 +38,10 @@ function MainRoutes() {
         </Route>
         {/* 404 페이지 */}
         <Route path="*" element={<NotFound />} />
+
+        {/* 소셜 로그인 */}
+        <Route path="/oauth/kakao" element={<KakaoAuth />} />
+        {/* <Route path="/oauth/naver" element={<NaverAuth />} /> */}
       </Route>
     </Routes>
   )

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -37,3 +37,7 @@ export interface UpdateUserInfoRequest {
   nickname: string
   phoneNumber: string
 }
+
+export interface UserKakaoLogin {
+  code: string
+}

--- a/src/utils/manage-token.ts
+++ b/src/utils/manage-token.ts
@@ -1,11 +1,11 @@
 export function getAccessToken() {
-  return localStorage.getItem('access')
+  return localStorage.getItem('access_token')
 }
 
 export function setAccessToken(token: string) {
-  localStorage.setItem('access', token)
+  localStorage.setItem('access_token', token)
 }
 
 export function clearAccessToken() {
-  localStorage.removeItem('access')
+  localStorage.removeItem('access_token')
 }


### PR DESCRIPTION
## 🚀 PR 요약

카카오 소셜 로그인 기능을 추가했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 카카오 로그인 인가코드를 서버에 전달하는 `useKakaoCallback` 훅 추가
- 카카오 로그인 시도 후 리다이렉트 될 콜백 페이지인 `KakaoAuth.tsx` 추가
- `response body`에서 받아오는 액세스 토큰 데이터 명을 `access`에서 `access_token`으로 수정

### 스크린 샷

아래 **gif**에서 `access_token`만 로컬 스토리지에 저장이 되고 `refresh_token`은 쿠키에 담기지 않고 있는데, 이는 로컬 환경에서 실행해서 그렇습니다(`refresh_token`을 쿠키에 저장할 때 설정한 도메인이랑 달라서).

배포 사이트에서는 정상 작동할 것으로 판단되어 머지 후 바로 확인하겠습니다.

https://github.com/user-attachments/assets/59e6f75d-bc99-4a76-8a0d-469413872f26

## 🔗 연관된 이슈

> closes #271
