### PR TITLE
Refactor: 내 정보 조회 msw 적용 & api 연결

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -37,13 +37,16 @@ const AvatarState = cva(
 interface AvatarProps
   extends ComponentProps<'img'>,
     VariantProps<typeof AvatarImage>,
-    VariantProps<typeof AvatarState> {}
+    VariantProps<typeof AvatarState> {
+  iconSize?: number
+}
 
 export default function Avatar({
   alt,
   size,
   state,
   className,
+  iconSize = 50,
   src,
 }: AvatarProps) {
   return (
@@ -55,7 +58,7 @@ export default function Avatar({
           className="h-full w-full rounded-full object-cover"
         />
       ) : (
-        <span>{alt?.charAt(0) || <UserIcon size={50} />}</span>
+        <span>{alt?.charAt(0) || <UserIcon size={iconSize} />}</span>
         // 마이페이지 사이드바에서 쓰인 아이콘으로 대체.
       )}
       <span aria-hidden="true" className={cn(AvatarState({ state }))} />

--- a/src/components/header/nav/NavProfile.tsx
+++ b/src/components/header/nav/NavProfile.tsx
@@ -64,8 +64,8 @@ function NavProfile({ onProfileClick }: { onProfileClick: () => void }) {
             size="sm"
             state="none"
             src={user.profileImageUrl}
-            alt={`
-              ${user.name}-profile-image`}
+            alt={user.profileImageUrl && `${user.name}-profile-image`}
+            iconSize={20}
           />
           <span className="text-primary-600 text-base font-medium">
             {user.name}

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -28,7 +28,7 @@ export default function useLogin(
         `${API_BASE_URL}/auth/email/login`,
         payload
       )
-      const newAccessToken = response.data.access_token
+      const newAccessToken = response.data.access
       return newAccessToken
     },
     onSuccess: async (newAccessToken: string) => {

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -17,7 +17,7 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
     mutationKey: ['token', 'refresh'],
     mutationFn: async () => {
       const response = await api.post(`${API_BASE_URL}/auth/refresh`)
-      const newAccessToken = response.data.access_token
+      const newAccessToken = response.data.access
       return newAccessToken
     },
     onSuccess: (newAccessToken: string) => {

--- a/src/hooks/api/auth/useUserInformation.ts
+++ b/src/hooks/api/auth/useUserInformation.ts
@@ -13,7 +13,7 @@ export default function useUserInformation<T = UserInformation>(
     ...options,
     queryKey: ['users', 'me'],
     queryFn: async () => {
-      const response = await api.get(`${MSW_BASE_URL}/users/me`)
+      const response = await api.get(`${MSW_BASE_URL}/info`)
       const data = response.data
 
       return {

--- a/src/hooks/api/auth/useUserInformation.ts
+++ b/src/hooks/api/auth/useUserInformation.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import { useLoginStore } from '@/store/useLoginStore'
 import type { UserInformation } from '@/types/api-response-types/auth-response-types'
 import api from '@/utils/axios'
@@ -13,7 +13,7 @@ export default function useUserInformation<T = UserInformation>(
     ...options,
     queryKey: ['users', 'me'],
     queryFn: async () => {
-      const response = await api.get(`${MSW_BASE_URL}/info`)
+      const response = await api.get(`${API_BASE_URL}/info/`)
       const data = response.data
 
       return {

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -1,6 +1,5 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
 import { http, HttpResponse, passthrough } from 'msw'
-import { userInformationMock } from '@/mocks/data/user-information-data'
 const ACCESS_TOKEN = `msw-access-token=access-token-test; Path=/; SameSite=Strict;`
 const REFRESH_TOKEN =
   'msw-refresh-token=refresh-token-test; Path=/; SameSite=Strict;'
@@ -41,20 +40,6 @@ const logout = http.post(`${MSW_BASE_URL}/auth/logout`, () => {
       headers: { 'Set-Cookie': `${REFRESH_TOKEN} Max-Age=0` },
     }
   )
-})
-
-// 내 정보 조회
-const getUserInformation = http.get(`${MSW_BASE_URL}/info`, ({ request }) => {
-  const header = request.headers.get('Authorization')
-  const hasBearerToken = header?.includes('Bearer')
-
-  if (!hasBearerToken) {
-    return HttpResponse.json(
-      { detail: 'Authentication required.' },
-      { status: 401 }
-    )
-  }
-  return HttpResponse.json(userInformationMock[0])
 })
 
 // 액세스 토큰 재발급
@@ -231,7 +216,6 @@ const passthroughPiscumPhotos = http.get(
 export const authHandlers = [
   login,
   logout,
-  getUserInformation,
   getRefreshToken,
   emailSendCode,
   emailVerify,

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -43,22 +43,19 @@ const logout = http.post(`${MSW_BASE_URL}/auth/logout`, () => {
   )
 })
 
-// 사용자 정보 조회
-const getUserInformation = http.get(
-  `${MSW_BASE_URL}/users/me`,
-  ({ request }) => {
-    const header = request.headers.get('Authorization')
-    const hasBearerToken = header?.includes('Bearer')
+// 내 정보 조회
+const getUserInformation = http.get(`${MSW_BASE_URL}/info`, ({ request }) => {
+  const header = request.headers.get('Authorization')
+  const hasBearerToken = header?.includes('Bearer')
 
-    if (!hasBearerToken) {
-      return HttpResponse.json(
-        { detail: 'Authentication required.' },
-        { status: 401 }
-      )
-    }
-    return HttpResponse.json(userInformationMock[0])
+  if (!hasBearerToken) {
+    return HttpResponse.json(
+      { detail: 'Authentication required.' },
+      { status: 401 }
+    )
   }
-)
+  return HttpResponse.json(userInformationMock[0])
+})
 
 // 액세스 토큰 재발급
 const getRefreshToken = http.post(`${MSW_BASE_URL}/auth/refresh`, () => {

--- a/src/mocks/handlers/user-info-handler.ts
+++ b/src/mocks/handlers/user-info-handler.ts
@@ -1,0 +1,21 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import { http, HttpResponse } from 'msw'
+import { userInformationMock } from '../data/user-information-data'
+
+// 내 정보 조회
+const getUserInformation = http.get(`${MSW_BASE_URL}/info`, ({ request }) => {
+  const header = request.headers.get('Authorization')
+  const hasBearerToken = header?.includes('Bearer')
+
+  if (!hasBearerToken) {
+    return HttpResponse.json(
+      { detail: 'Authentication required.' },
+      { status: 401 }
+    )
+  }
+  return HttpResponse.json(userInformationMock[0])
+})
+
+// 내 정보 수정 -> http.patch(`${MSW_BASE_URL}/info/edit`)
+
+export const userInfoHandlers = [getUserInformation]

--- a/src/utils/formatted-phone.ts
+++ b/src/utils/formatted-phone.ts
@@ -4,3 +4,11 @@ export const formattedPhoneToE164KR = (phoneNumber: string) => {
   const slicedPhoneNumber = phoneNumber.substring(1)
   return `+82${slicedPhoneNumber}`
 }
+
+export const formattedPhoneWithHyphen = (phoneNumber: string) => {
+  if (phoneNumber.startsWith('010')) return phoneNumber
+
+  const frontNumber = phoneNumber.substring(5, 9)
+  const backNumber = phoneNumber.substring(9, 13)
+  return `010-${frontNumber}-${backNumber}`
+}

--- a/src/utils/map-user-info.ts
+++ b/src/utils/map-user-info.ts
@@ -1,5 +1,6 @@
 import type { UserInformation } from '@/types'
 import type { InfoDescription } from '@/components/my-page/my-info/InfoDescription'
+import { formattedPhoneWithHyphen } from './formatted-phone'
 
 // 마이페이지 내정보 조회를 위한 유틸 생성
 export function mapUserInfoToDescription(
@@ -7,7 +8,10 @@ export function mapUserInfoToDescription(
 ): InfoDescription[] {
   return [
     { title: '이메일', detail: user.email ?? '' },
-    { title: '휴대폰 번호', detail: user.phoneNumber ?? '' },
+    {
+      title: '휴대폰 번호',
+      detail: formattedPhoneWithHyphen(user.phoneNumber) ?? '',
+    },
     { title: '닉네임', detail: user.nickname ?? '' },
     { title: '생년월일', detail: user.birthday ?? '' },
     { title: '이름', detail: user.name ?? '' },


### PR DESCRIPTION
## 🚀 PR 요약

내 정보 조회 hook에 적용된 msw 로직을 수정하고 api 연결을 확인했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- swagger에 맞게 내 정보 조회 api 엔드포인트 수정
- 헤더 UI와 마이페이지에 내 정보가 알맞는 형태로 보이도록 수정
- `useLogin`과 `useTokenRefresh`에서 `response body`로 넘어오는 액세스 토큰이 `access_token`이 아닌 `access`로 전달되고 있기 때문에 알맞게 수정

### 참고 사항

- 서버에서 휴대전화 번호가 넘어올 때 **+821012345678**와 같은 형식으로 전달 되기 때문에 프론트 쪽에서 **010-1234-5678** 형태로 변환시켰습니다. 마찬가지로 서버로 휴대전화 번호를 `request body`에 담아 전달할 때도 **+821012345678**와 같은 형태로 보내야 합니다.

### 스크린 샷

![StudyHub-Chrome2025-09-2723-22-45-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ea188e42-edaa-4725-a0a4-157abe4a3fde)

## 🔗 연관된 이슈

> closes #274
