### PR TITLE
Fix: 로그아웃 시 랜딩페이지로 이동

### DIFF
--- a/src/components/header/nav/NavProfile.tsx
+++ b/src/components/header/nav/NavProfile.tsx
@@ -15,7 +15,7 @@ function NavProfile({ onProfileClick }: { onProfileClick: () => void }) {
       name: data.name,
       profileImageUrl: data.profileImageUrl,
     }),
-    queryKey: ['users', 'me'],
+    queryKey: ['info'],
   })
 
   if (!isLoggedIn)

--- a/src/hooks/api/auth/useKakaoCallback.ts
+++ b/src/hooks/api/auth/useKakaoCallback.ts
@@ -32,7 +32,7 @@ export default function useKakaoCallback(
     onSuccess: async (newAccessToken: string) => {
       setAccessToken(newAccessToken)
       setIsLoggedIn(true)
-      await qc.invalidateQueries({ queryKey: ['users', 'me'] })
+      await qc.invalidateQueries({ queryKey: ['info'] })
       triggerToast(
         'success',
         'Kakao Login 🎉',

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -34,7 +34,7 @@ export default function useLogin(
     onSuccess: async (newAccessToken: string) => {
       setAccessToken(newAccessToken)
       setIsLoggedIn(true)
-      await qc.invalidateQueries({ queryKey: ['users', 'me'] })
+      await qc.invalidateQueries({ queryKey: ['info'] })
       triggerToast('success', 'Login 🎉', '로그인이 완료되었습니다.')
       navigate('/')
     },

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -8,11 +8,13 @@ import {
   useQueryClient,
   type UseMutationOptions,
 } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
 
 export default function useLogout(options?: UseMutationOptions) {
   const qc = useQueryClient()
   const { triggerToast } = useToast()
   const { setIsLoggedIn } = useLoginStore()
+  const navigate = useNavigate()
 
   return useMutation({
     mutationKey: ['auth', 'logout'],
@@ -24,6 +26,7 @@ export default function useLogout(options?: UseMutationOptions) {
       clearAccessToken()
       qc.removeQueries({ queryKey: ['info'] })
       triggerToast('success', 'Logout 👋', '로그아웃이 완료되었습니다.')
+      navigate('/')
     },
     ...options,
   })

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -15,14 +15,14 @@ export default function useLogout(options?: UseMutationOptions) {
   const { setIsLoggedIn } = useLoginStore()
 
   return useMutation({
-    mutationKey: ['users', 'logout'],
+    mutationKey: ['auth', 'logout'],
     mutationFn: async () => {
       await api.post(`${API_BASE_URL}/auth/logout`)
     },
     onSuccess: () => {
       setIsLoggedIn(false)
       clearAccessToken()
-      qc.removeQueries({ queryKey: ['users', 'me'] })
+      qc.removeQueries({ queryKey: ['info'] })
       triggerToast('success', 'Logout 👋', '로그아웃이 완료되었습니다.')
     },
     ...options,

--- a/src/hooks/api/auth/useTokenRefresh.ts
+++ b/src/hooks/api/auth/useTokenRefresh.ts
@@ -23,11 +23,11 @@ export default function useTokenRefresh(options?: UseMutationOptions) {
     onSuccess: (newAccessToken: string) => {
       setAccessToken(newAccessToken)
       setIsLoggedIn(true)
-      qc.invalidateQueries({ queryKey: ['users', 'me'] })
+      qc.invalidateQueries({ queryKey: ['info'] })
     },
     onError: () => {
       setIsLoggedIn(false)
-      qc.removeQueries({ queryKey: ['users', 'me'] })
+      qc.removeQueries({ queryKey: ['info'] })
     },
   })
 }

--- a/src/hooks/api/auth/useUserInformation.ts
+++ b/src/hooks/api/auth/useUserInformation.ts
@@ -11,7 +11,7 @@ export default function useUserInformation<T = UserInformation>(
 
   return useQuery<UserInformation, Error, T>({
     ...options,
-    queryKey: ['users', 'me'],
+    queryKey: ['info'],
     queryFn: async () => {
       const response = await api.get(`${API_BASE_URL}/info/`)
       const data = response.data


### PR DESCRIPTION
## 🚀 PR 요약

로그아웃에 성공하면 `useNavigate`를 이용해 랜딩 페이지로 이동하도록 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그아웃 성공 시 랜딩 페이지(`'/'`)로 이동하도록 수정
- auth 관련 api 요청 hook의 queryKey를 컨벤션에 맞게 수정

### 스크린 샷

![StudyHub-Chrome2025-09-2910-42-57-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e357ff7f-5eec-4c36-9ff0-a207f9b243bc)

## 🔗 연관된 이슈

> closes #276
