### PR TITLE
Refactor: App.tsx에 MainRoutes 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import useAxiosInterceptor from '@/hooks/api/useAxiosInterceptor'
 import { useEffect } from 'react'
-import { getAccessToken } from './utils'
-import useTokenRefresh from './hooks/api/auth/useTokenRefresh'
-import MainRoutes from './routes/MainRoutes'
+import { getAccessToken } from '@/utils'
+import useTokenRefresh from '@/hooks/api/auth/useTokenRefresh'
+import MainRoutes from '@/routes/MainRoutes'
 
 function App() {
   const refreshToken = useTokenRefresh()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
-import TestRoutes from '@/routes/TestRoutes'
 import useAxiosInterceptor from '@/hooks/api/useAxiosInterceptor'
 import { useEffect } from 'react'
 import { getAccessToken } from './utils'
 import useTokenRefresh from './hooks/api/auth/useTokenRefresh'
+import MainRoutes from './routes/MainRoutes'
 
 function App() {
   const refreshToken = useTokenRefresh()
@@ -17,7 +17,7 @@ function App() {
 
   useAxiosInterceptor()
 
-  return <TestRoutes />
+  return <MainRoutes />
 }
 
 export default App

--- a/src/pages/TestHub.tsx
+++ b/src/pages/TestHub.tsx
@@ -8,8 +8,8 @@ function TestHub() {
   const { pathname } = useLocation()
 
   useEffect(() => {
-    if (pathname === '/test-hub' && testPages.length > 0) {
-      navigate(`/test-hub/${testPages[0].route}`, { replace: true })
+    if (pathname === '/test/test-hub' && testPages.length > 0) {
+      navigate(`/test/test-hub/${testPages[0].route}`, { replace: true })
     }
   }, [pathname, navigate])
 
@@ -23,7 +23,7 @@ function TestHub() {
               <Button
                 key={p.key}
                 variant="outline"
-                onClick={() => navigate(`/test-hub/${p.route}`)}
+                onClick={() => navigate(`/test/test-hub/${p.route}`)}
                 className="px-10 py-5"
               >
                 {p.name}

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -13,13 +13,13 @@ import {
 } from '@/pages'
 import KakaoAuth from '@/pages/auth/KakaoAuth'
 import { Route, Routes } from 'react-router'
+import TestRoutes from './TestRoutes'
 
 function MainRoutes() {
   return (
     <Routes>
-      <Route element={<RootLayout />}>
-        {/* TODO: /landing -> index로 수정 */}
-        <Route path="landing" element={<LandingPage />} />
+      <Route path="/" element={<RootLayout />}>
+        <Route index element={<LandingPage />} />
 
         <Route path="auth" element={<AuthLayout />}>
           <Route path="login" element={<Login />} />
@@ -36,6 +36,7 @@ function MainRoutes() {
           <Route path="bookmarked/" element={<Bookmark />} />
           <Route path="bookmarked/:content" element={<Bookmark />} />
         </Route>
+
         {/* 404 페이지 */}
         <Route path="*" element={<NotFound />} />
 
@@ -43,6 +44,9 @@ function MainRoutes() {
         <Route path="/oauth/kakao" element={<KakaoAuth />} />
         {/* <Route path="/oauth/naver" element={<NaverAuth />} /> */}
       </Route>
+
+      {/* 테스트 허브 */}
+      <Route path="/test/*" element={<TestRoutes />} />
     </Routes>
   )
 }

--- a/src/routes/TestRoutes.tsx
+++ b/src/routes/TestRoutes.tsx
@@ -3,15 +3,14 @@ import TestHub from '@/pages/TestHub'
 import { testPages } from '@/utils'
 import { lazy, Suspense } from 'react'
 import { Route, Routes, Link } from 'react-router'
-import MainRoutes from './MainRoutes'
 
-function Root() {
+function TestMenu() {
   const randomString = Math.random().toString(36).substring(2, 11)
 
   return (
     <div className="flex h-screen items-center justify-center gap-10">
       <Button className="px-10 py-6 text-2xl">
-        <Link to="/landing">사이트 메인</Link>
+        <Link to="/">사이트 메인</Link>
       </Button>
       <Button className="px-10 py-6 text-2xl">
         <Link to="/my-page">마이 페이지</Link>
@@ -20,7 +19,7 @@ function Root() {
         <Link to={`/${randomString}`}>404 페이지</Link>
       </Button>
       <Button className="px-10 py-6 text-2xl">
-        <Link to="/test-hub">테스트 허브</Link>
+        <Link to="/test/test-hub">테스트 허브</Link>
       </Button>
     </div>
   )
@@ -29,8 +28,7 @@ function Root() {
 function TestRoutes() {
   return (
     <Routes>
-      <Route path="/" element={<Root />} />
-      <Route path="/*" element={<MainRoutes />} />
+      <Route path="/" element={<TestMenu />} />
       <Route path="/test-hub/*" element={<TestHub />}>
         {testPages.map((p) => {
           const Page = lazy(p.loader)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 // utils
 import { cn, getChatRoomWebSocketUrl } from '@/utils/utils'
-import { testPages } from '@/utils/registryTestPages'
+import { testPages } from '@/utils/registry-test-pages'
 import {
   formattedAppliedAt,
   formattedCloseAt,

--- a/src/utils/registry-test-pages.ts
+++ b/src/utils/registry-test-pages.ts
@@ -31,7 +31,7 @@ export const testPages = Object.entries(modules)
   .map(([key, loader]) => {
     const base = removeTestSuffix(getFileNameFromPath(key))
     const name = toDisplayName(base)
-    const route = `test-pages/${toKebabCase(base)}`
+    const route = `${toKebabCase(base)}`
     return { key, name, route, loader }
   })
   .sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
## 🚀 PR 요약

**App.tsx**에 `TestRoutes` 대신 `MainRoutes`를 연결하도록 수정했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 랜딩페이지 라우트 경로를 `'/'`로 수정
- **App.tsx**에 `MainRoutes` 적용
- `TestHub` 관련 라우트 경로 수정
- `'/test'` 입력 시 `TestMenu`로 이동하고, 테스트 허브 버튼 클릭 시 `'/test/test-hub'` 경로로 이동하도록 수정

### 참고 사항

- 사이트 최초 접속 시 랜딩 페이지가 보이도록 수정했습니다.
- url 입력 창에 직접 `'/test'` 입력 시 `TestMenu`로 넘어갈 수 있게 수정했습니다.

### 스크린 샷

![StudyHub-Chrome2025-09-2819-19-40-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1269f18a-e920-452b-9af6-e1cde6ef2286)

## 🔗 연관된 이슈

> closes #277 
