### PR TITLE
Feature: 이메일 찾기 & 비밀번호 재설정 페이지 msw 적용 및 일부 api 연결

### DIFF
--- a/src/components/auth/find-email/FindEmailThirdStep.tsx
+++ b/src/components/auth/find-email/FindEmailThirdStep.tsx
@@ -5,10 +5,9 @@ import { Link } from 'react-router'
 
 interface FindEmailThirdStepProps {
   email: string
-  createdAt: string
 }
 
-function FindEmailThirdStep({ email, createdAt }: FindEmailThirdStepProps) {
+function FindEmailThirdStep({ email }: FindEmailThirdStepProps) {
   return (
     <article className="flex flex-col gap-12">
       <div className="flex flex-col items-center">
@@ -26,9 +25,6 @@ function FindEmailThirdStep({ email, createdAt }: FindEmailThirdStepProps) {
       </div>
       <div className="mb-15 flex flex-col items-center gap-1 rounded-lg border border-solid border-gray-200 bg-gray-50 py-4">
         <span className="text-base font-medium text-gray-900">{email}</span>
-        <span className="text-sm font-normal text-gray-500">
-          가입일: {createdAt}
-        </span>
       </div>
       <div className="flex gap-2">
         <Button className="bg-success-500 hover:bg-success-600 active:bg-success-800 flex-1 py-3 text-base font-medium">

--- a/src/components/auth/find-password/FindPasswordSecondStep.tsx
+++ b/src/components/auth/find-password/FindPasswordSecondStep.tsx
@@ -17,6 +17,7 @@ import {
   FindPasswordStep2Schema,
   type FindPasswordStep2Type,
 } from '@/schemas/form-schema/find-password-schema'
+import { cn } from '@/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { MailCheck } from 'lucide-react'
 import { useEffect } from 'react'
@@ -50,9 +51,8 @@ function FindPasswordSecondStep({
 
   const onSubmit = (value: FindPasswordStep2Type) => onNext(value)
 
-  // TODO: 비밀번호 찾기 인증코드 전송 api에 맞게 수정 필요
   useEffect(() => {
-    handleCodeSend('email', email)
+    handleCodeSend('resetPassword', email)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -69,14 +69,18 @@ function FindPasswordSecondStep({
         <div className={InputFieldColStyle}>
           <div className={InputFieldRowStyle}>
             <Input
+              disabled={!isCodeSent.resetPassword}
               {...register('code')}
               placeholder="인증코드 6자리를 입력해주세요"
+              className={cn(
+                isCodeVerified.resetPassword &&
+                  'disabled:bg-white disabled:text-black'
+              )}
             />
             <AuthVerifyButton
-              disabled={!isCodeSent.phoneNumber}
-              // TODO: 비밀번호 찾기 인증코드 검증 api에 맞게 수정 필요
+              disabled={!isCodeSent.resetPassword}
               onClick={() =>
-                handleCodeVerify('email', {
+                handleCodeVerify('resetPassword', {
                   email: email,
                   verificationCode: getValues('code'),
                 })
@@ -90,7 +94,7 @@ function FindPasswordSecondStep({
           )}
         </div>
 
-        <AuthSubmitButton disabled={!isValid || !isCodeVerified.phoneNumber}>
+        <AuthSubmitButton disabled={!isValid || !isCodeVerified.resetPassword}>
           인증하기
         </AuthSubmitButton>
         <Button variant="outline" onClick={onPrev} className="w-full py-4">

--- a/src/constants/api-endpoints.ts
+++ b/src/constants/api-endpoints.ts
@@ -9,4 +9,9 @@ export const PUBLIC_ENDPOINTS = [
   'auth/phone/verify',
   'auth/refresh',
   'auth/recover-account',
+  'auth/find-email/send',
+  'auth/find-email/verify',
+  'auth/reset-password/send',
+  'auth/reset-password/verify',
+  'auth/reset-password',
 ] as const

--- a/src/hooks/api/auth/useFindEmailSendCode.ts
+++ b/src/hooks/api/auth/useFindEmailSendCode.ts
@@ -1,0 +1,41 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
+import type { UserFindEmailSendCode } from '@/types/api-request-types/auth-request-types'
+import api from '@/utils/axios'
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+export function useFindEmailSendCode(
+  options?: UseMutationOptions<unknown, Error, UserFindEmailSendCode>
+) {
+  const { triggerToast } = useToast()
+
+  return useMutation<unknown, Error, UserFindEmailSendCode>({
+    ...options,
+    mutationKey: ['auth', 'find-email', 'send'],
+    mutationFn: async ({ phoneNumber }) => {
+      await api.post(`${MSW_BASE_URL}/auth/find-email/send`, {
+        phone_number: phoneNumber,
+      })
+    },
+    onSuccess: () => {
+      triggerToast(
+        'success',
+        '휴대전화 인증 코드를 전송했습니다 ✉️',
+        '확인 후 입력해주세요'
+      )
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 휴대전화 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useFindEmailVerify.ts
+++ b/src/hooks/api/auth/useFindEmailVerify.ts
@@ -1,0 +1,44 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
+import type { UserFindEmailVerify } from '@/types/api-request-types/auth-request-types'
+import api from '@/utils/axios'
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+export function useFindEmailVerify(
+  options?: UseMutationOptions<string, Error, UserFindEmailVerify>
+) {
+  const { triggerToast } = useToast()
+
+  return useMutation<string, Error, UserFindEmailVerify>({
+    ...options,
+    mutationKey: ['auth', 'find-email', 'verify'],
+    mutationFn: async ({ name, phoneNumber, verificationCode }) => {
+      const response = await api.post(
+        `${MSW_BASE_URL}/auth/find-email/verify`,
+        {
+          name: name,
+          phone_number: phoneNumber,
+          verification_code: verificationCode,
+        }
+      )
+      const email = response.data.email
+      return email
+    },
+    onSuccess: () => {
+      triggerToast('success', '인증 완료 ✅', '다음 단계를 진행해주세요')
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useResetPassword.ts
+++ b/src/hooks/api/auth/useResetPassword.ts
@@ -4,18 +4,20 @@ import type { UserResetPassword } from '@/types/api-request-types/auth-request-t
 import api from '@/utils/axios'
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
+import { useNavigate } from 'react-router'
 
 export function useResetPassword(
   options?: UseMutationOptions<unknown, Error, UserResetPassword>
 ) {
   const { triggerToast } = useToast()
+  const navigate = useNavigate()
 
   return useMutation<unknown, Error, UserResetPassword>({
     ...options,
     mutationKey: ['auth', 'reset-password'],
-    mutationFn: async ({ newPassword }) => {
+    mutationFn: async ({ password }) => {
       await api.patch(`${MSW_BASE_URL}/auth/reset-password`, {
-        new_password: newPassword,
+        password: password,
       })
     },
     onSuccess: () => {
@@ -24,6 +26,7 @@ export function useResetPassword(
         'Reset Password 🎊',
         '비밀번호 재설정이 완료되었습니다'
       )
+      navigate('/auth/login')
     },
     onError: (error) => {
       if (error instanceof AxiosError) {

--- a/src/hooks/api/auth/useResetPassword.ts
+++ b/src/hooks/api/auth/useResetPassword.ts
@@ -1,0 +1,41 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
+import type { UserResetPassword } from '@/types/api-request-types/auth-request-types'
+import api from '@/utils/axios'
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+export function useResetPassword(
+  options?: UseMutationOptions<unknown, Error, UserResetPassword>
+) {
+  const { triggerToast } = useToast()
+
+  return useMutation<unknown, Error, UserResetPassword>({
+    ...options,
+    mutationKey: ['auth', 'reset-password'],
+    mutationFn: async ({ newPassword }) => {
+      await api.patch(`${MSW_BASE_URL}/auth/reset-password`, {
+        new_password: newPassword,
+      })
+    },
+    onSuccess: () => {
+      triggerToast(
+        'success',
+        'Reset Password 🎊',
+        '비밀번호 재설정이 완료되었습니다'
+      )
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 비밀번호 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useResetPasswordSendCode.ts
+++ b/src/hooks/api/auth/useResetPasswordSendCode.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import useToast from '@/hooks/useToast'
 import type { UserResetPasswordSendCode } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
@@ -14,7 +14,7 @@ export function useResetPasswordSendCode(
     ...options,
     mutationKey: ['auth', 'reset-password', 'send'],
     mutationFn: async ({ email }) => {
-      await api.post(`${MSW_BASE_URL}/auth/reset-password/send`, {
+      await api.post(`${API_BASE_URL}/auth/reset-password/send`, {
         email: email,
       })
     },

--- a/src/hooks/api/auth/useResetPasswordSendCode.ts
+++ b/src/hooks/api/auth/useResetPasswordSendCode.ts
@@ -1,0 +1,41 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
+import type { UserResetPasswordSendCode } from '@/types/api-request-types/auth-request-types'
+import api from '@/utils/axios'
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+export function useResetPasswordSendCode(
+  options?: UseMutationOptions<unknown, Error, UserResetPasswordSendCode>
+) {
+  const { triggerToast } = useToast()
+
+  return useMutation<unknown, Error, UserResetPasswordSendCode>({
+    ...options,
+    mutationKey: ['auth', 'reset-password', 'send'],
+    mutationFn: async ({ email }) => {
+      await api.post(`${MSW_BASE_URL}/auth/reset-password/send`, {
+        email: email,
+      })
+    },
+    onSuccess: () => {
+      triggerToast(
+        'success',
+        '이메일 인증 코드를 전송했습니다 ✉️',
+        '확인 후 입력해주세요'
+      )
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 이메일 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useResetPasswordVerify.ts
+++ b/src/hooks/api/auth/useResetPasswordVerify.ts
@@ -1,0 +1,38 @@
+import { MSW_BASE_URL } from '@/constants/url-constants'
+import useToast from '@/hooks/useToast'
+import type { UserResetPasswordVerify } from '@/types/api-request-types/auth-request-types'
+import api from '@/utils/axios'
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+export function useResetPasswordVerify(
+  options?: UseMutationOptions<unknown, Error, UserResetPasswordVerify>
+) {
+  const { triggerToast } = useToast()
+
+  return useMutation<unknown, Error, UserResetPasswordVerify>({
+    ...options,
+    mutationKey: ['auth', 'reset-password', 'verify'],
+    mutationFn: async ({ email, verificationCode }) => {
+      await api.post(`${MSW_BASE_URL}/auth/reset-password/verify`, {
+        email: email,
+        verification_code: verificationCode,
+      })
+    },
+    onSuccess: () => {
+      triggerToast('success', '인증 완료 ✅', '다음 단계를 진행해주세요')
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const status = error.status
+        if (status === 400) {
+          triggerToast('error', '잘못된 인증코드 형식입니다')
+        } else {
+          triggerToast('error', '잠시 후 다시 시도해주세요')
+        }
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useResetPasswordVerify.ts
+++ b/src/hooks/api/auth/useResetPasswordVerify.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from '@/constants/url-constants'
+import { API_BASE_URL } from '@/constants/url-constants'
 import useToast from '@/hooks/useToast'
 import type { UserResetPasswordVerify } from '@/types/api-request-types/auth-request-types'
 import api from '@/utils/axios'
@@ -14,7 +14,7 @@ export function useResetPasswordVerify(
     ...options,
     mutationKey: ['auth', 'reset-password', 'verify'],
     mutationFn: async ({ email, verificationCode }) => {
-      await api.post(`${MSW_BASE_URL}/auth/reset-password/verify`, {
+      await api.post(`${API_BASE_URL}/auth/reset-password/verify`, {
         email: email,
         verification_code: verificationCode,
       })

--- a/src/hooks/useVerificationCode.ts
+++ b/src/hooks/useVerificationCode.ts
@@ -12,21 +12,31 @@ import type {
   UserFindEmailVerify,
   UserPhoneSendCode,
   UserPhoneVerify,
+  UserResetPasswordSendCode,
+  UserResetPasswordVerify,
 } from '@/types/api-request-types/auth-request-types'
 import { formattedPhoneToE164KR } from '@/utils/formatted-phone'
 import { useUserRecoverSendCode, useUserRecoverVerify } from '@/hooks/api'
 import type { UserRecoverVerifyBody } from '@/types/api-request-types/user-recover-request-types'
 import { useFindEmailSendCode } from './api/auth/useFindEmailSendCode'
 import { useFindEmailVerify } from './api/auth/useFindEmailVerify'
+import { useResetPasswordSendCode } from './api/auth/useResetPasswordSendCode'
+import { useResetPasswordVerify } from './api/auth/useResetPasswordVerify'
 
 const TIMER_DURATION_MS = 180000
-type labelType = 'email' | 'phoneNumber' | 'userRecover' | 'findEmail'
+type labelType =
+  | 'email'
+  | 'phoneNumber'
+  | 'userRecover'
+  | 'findEmail'
+  | 'resetPassword'
 
 interface VerifyDataMap {
   email: UserEmailVerify
   phoneNumber: UserPhoneVerify
   userRecover: UserRecoverVerifyBody
   findEmail: UserFindEmailVerify
+  resetPassword: UserResetPasswordVerify
 }
 
 function useVerificationCode() {
@@ -36,22 +46,26 @@ function useVerificationCode() {
   const phoneSendCode = usePhoneSendCode()
   const userRecoverSendCode = useUserRecoverSendCode()
   const findEmailSendCode = useFindEmailSendCode()
+  const resetPasswordSendCode = useResetPasswordSendCode()
   const emailVerify = useEmailVerify()
   const phoneVerify = usePhoneVerify()
   const userRecoverVerify = useUserRecoverVerify()
   const findEmailVerify = useFindEmailVerify()
+  const resetPasswordVerify = useResetPasswordVerify()
 
   const [isCodeSent, SetIsCodeSent] = useState({
     email: false,
     phoneNumber: false,
     userRecover: false,
     findEmail: false,
+    resetPassword: false,
   })
   const [isCodeVerified, SetIsCodeVerified] = useState({
     email: false,
     phoneNumber: false,
     userRecover: false,
     findEmail: false,
+    resetPassword: false,
   })
   const timer = {
     email: useTimer(TIMER_DURATION_MS, () =>
@@ -82,6 +96,13 @@ function useVerificationCode() {
         '다시 시도해주세요'
       )
     ),
+    resetPassword: useTimer(TIMER_DURATION_MS, () =>
+      triggerToast(
+        'warning',
+        '이메일 인증 시간이 만료되었습니다',
+        '다시 시도해주세요'
+      )
+    ),
   }
 
   const handleCodeSend = async (label: labelType, value: string) => {
@@ -101,6 +122,10 @@ function useVerificationCode() {
       const phoneNumberE164KR = formattedPhoneToE164KR(value)
       const data: UserFindEmailSendCode = { phoneNumber: phoneNumberE164KR }
       await findEmailSendCode.mutateAsync(data)
+    }
+    if (label === 'resetPassword') {
+      const data: UserResetPasswordSendCode = { email: value }
+      await resetPasswordSendCode.mutateAsync(data)
     }
     SetIsCodeSent((prev) => ({ ...prev, [label]: true }))
     timer[label].startTimer()
@@ -136,6 +161,10 @@ function useVerificationCode() {
       }
       const email = await findEmailVerify.mutateAsync(data)
       setFindEmailValue(email)
+    }
+    if (label === 'resetPassword') {
+      const data: UserResetPasswordVerify = verifyData as UserEmailVerify
+      await resetPasswordVerify.mutateAsync(data)
     }
     SetIsCodeVerified((prev) => ({ ...prev, [label]: true }))
     SetIsCodeSent((prev) => ({ ...prev, [label]: false }))

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -1,5 +1,6 @@
 import { MSW_BASE_URL } from '@/constants/url-constants'
 import { http, HttpResponse, passthrough } from 'msw'
+import { userInformationMock } from '../data/user-information-data'
 const ACCESS_TOKEN = `msw-access-token=access-token-test; Path=/; SameSite=Strict;`
 const REFRESH_TOKEN =
   'msw-refresh-token=refresh-token-test; Path=/; SameSite=Strict;'
@@ -206,6 +207,138 @@ const signup = http.post(
   }
 )
 
+// 이메일 찾기 - 휴대전화 인증코드 전송
+const findEmailSendCode = http.post(
+  `${MSW_BASE_URL}/auth/find-email/send`,
+  async ({ request }) => {
+    const body = await request.clone().json()
+
+    if (!body.phone_number) {
+      return HttpResponse.json(
+        {
+          error: '잘못된 입력 형식입니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '휴대전화 인증코드를 전송했습니다',
+      },
+      {
+        status: 200,
+      }
+    )
+  }
+)
+
+// 이메일 찾기 - 휴대전화 인증코드 검증
+const findEmailVerify = http.post(
+  `${MSW_BASE_URL}/auth/find-email/verify`,
+  async ({ request }) => {
+    const body = await request.clone().json()
+
+    if (!body.name || !body.phone_number || !body.verification_code) {
+      return HttpResponse.json(
+        {
+          error: '잘못된 입력 형식입니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '휴대전화 인증코드가 확인되었습니다',
+        email: userInformationMock[0].email,
+      },
+      {
+        status: 200,
+      }
+    )
+  }
+)
+
+// 비밀번호 찾기 - 이메일 인증코드 전송
+const resetPasswordSendCode = http.post(
+  `${MSW_BASE_URL}/auth/reset-password/send`,
+  async ({ request }) => {
+    const body = await request.clone().json()
+
+    if (!body.email) {
+      return HttpResponse.json(
+        {
+          error: '잘못된 입력 형식입니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '이메일 인증코드를 전송했습니다',
+      },
+      {
+        status: 200,
+      }
+    )
+  }
+)
+
+// 비밀번호 찾기 - 이메일 인증코드 검증
+const resetPasswordVerify = http.post(
+  `${MSW_BASE_URL}/auth/reset-password/verify`,
+  async ({ request }) => {
+    const body = await request.clone().json()
+
+    if (!body.email || !body.verification_code) {
+      return HttpResponse.json(
+        {
+          error: '잘못된 입력 형식입니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '이메일 인증코드가 확인되었습니다',
+        email: userInformationMock[0].email,
+      },
+      {
+        status: 200,
+      }
+    )
+  }
+)
+
+// 새 비밀번호 설정
+const resetPassword = http.patch(
+  `${MSW_BASE_URL}/auth/reset-password`,
+  async ({ request }) => {
+    const body = await request.clone().json()
+
+    if (!body.password) {
+      return HttpResponse.json(
+        {
+          error: '잘못된 입력 형식입니다',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        detail: '새 비밀번호 설정이 완료되었습니다',
+      },
+      {
+        status: 200,
+      }
+    )
+  }
+)
+
 // 외부 이미지 api
 const passthroughPiscumPhotos = http.get(
   `https://picsum.photos/id/:rest*`,
@@ -223,5 +356,10 @@ export const authHandlers = [
   phoneSendCode,
   phoneVerify,
   signup,
+  findEmailSendCode,
+  findEmailVerify,
+  resetPasswordSendCode,
+  resetPasswordVerify,
+  resetPassword,
   passthroughPiscumPhotos,
 ]

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -32,6 +32,7 @@ const login = http.post(
   }
 )
 
+// 로그아웃
 const logout = http.post(`${MSW_BASE_URL}/auth/logout`, () => {
   return HttpResponse.json(
     { detail: '로그아웃이 완료되었습니다' },

--- a/src/pages/auth/FindEmail.tsx
+++ b/src/pages/auth/FindEmail.tsx
@@ -18,7 +18,7 @@ function FindEmail() {
   const [stepHistory, setStepHistory] = useState({
     step1: { name: '', phoneNumber: '' },
     step2: { code: '' },
-    step3: { email: '', createdAt: '' },
+    step3: { email: '' },
   })
 
   return (
@@ -51,6 +51,7 @@ function FindEmail() {
       {currentStep === 2 && (
         <FindEmailSecondStep
           defaultValues={stepHistory.step2}
+          name={stepHistory.step1.name}
           phoneNumber={stepHistory.step1.phoneNumber}
           onPrev={() => setCurrentStep(1)}
           onNext={(value) => {
@@ -60,21 +61,22 @@ function FindEmail() {
                 ...prev.step2,
                 ...value,
               },
-              step3: {
-                ...prev.step3,
-                email: 'test@test.com',
-                createdAt: '2025-01-15',
-              },
             }))
             setCurrentStep(3)
+          }}
+          onSetEmail={(value) => {
+            setStepHistory((prev) => ({
+              ...prev,
+              step3: {
+                ...prev.step3,
+                email: value,
+              },
+            }))
           }}
         />
       )}
       {currentStep === 3 && (
-        <FindEmailThirdStep
-          email={stepHistory.step3.email}
-          createdAt={stepHistory.step3.createdAt}
-        />
+        <FindEmailThirdStep email={stepHistory.step3.email} />
       )}
     </AuthContainer>
   )

--- a/src/pages/auth/FindPassword.tsx
+++ b/src/pages/auth/FindPassword.tsx
@@ -8,10 +8,9 @@ import { useState } from 'react'
 import FindPasswordFirstStep from '@/components/auth/find-password/FindPasswordFirstStep'
 import FindPasswordSecondStep from '@/components/auth/find-password/FindPasswordSecondStep'
 import FindPasswordThirdStep from '@/components/auth/find-password/FindPasswordThirdStep'
-import { useNavigate } from 'react-router'
-import { useToast } from '@/hooks'
 import { InputFieldColStyle } from '@/constants/auth-variants'
 import { cn } from '@/utils'
+import { useResetPassword } from '@/hooks/api/auth/useResetPassword'
 
 const FIND_EMAIL_STEP_LIST = ['이메일입력', '이메일인증', '비밀번호재설정']
 
@@ -22,8 +21,7 @@ function FindPassword() {
     step2: { code: '' },
     step3: { password: '', confirmPassword: '' },
   })
-  const navigate = useNavigate()
-  const { triggerToast } = useToast()
+  const resetPassword = useResetPassword()
 
   return (
     <AuthContainer className="flex flex-col gap-10">
@@ -77,9 +75,12 @@ function FindPassword() {
       {currentStep === 3 && (
         <FindPasswordThirdStep
           defaultValues={stepHistory.step3}
-          onNext={() => {
-            navigate('/auth/login')
-            triggerToast('success', '비밀번호 변경이 완료되었습니다.')
+          onNext={(value) => {
+            setStepHistory((prev) => ({
+              ...prev,
+              step3: { ...prev.step3, ...value },
+            }))
+            resetPassword.mutate({ password: value.password })
           }}
         />
       )}

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -62,5 +62,5 @@ export interface UserResetPasswordVerify {
 }
 
 export interface UserResetPassword {
-  newPassword: string
+  password: string
 }

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -41,3 +41,26 @@ export interface UpdateUserInfoRequest {
 export interface UserKakaoLogin {
   code: string
 }
+
+export interface UserFindEmailSendCode {
+  phoneNumber: string
+}
+
+export interface UserFindEmailVerify {
+  name: string
+  phoneNumber: string
+  verificationCode: string
+}
+
+export interface UserResetPasswordSendCode {
+  email: string
+}
+
+export interface UserResetPasswordVerify {
+  email: string
+  verificationCode: string
+}
+
+export interface UserResetPassword {
+  newPassword: string
+}


### PR DESCRIPTION
## 🚀 PR 요약

이메일 찾기 페이지와 비밀번호 재설정 페이지에 msw를 적용하고, 비밀번호 재설정 인증코드 전송 & 검증 api를 연결했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- msw 적용
  - 이메일 찾기 인증코드 전송
  - 이메일 찾기 인증코드 검증
  - 비밀번호 재설정 인증코드 전송
  - 비밀번호 재설정 인증코드 검증
  - 새 비밀번호 설정
- api 연결
  - 비밀번호 재설정 인증코드 전송
  - 비밀번호 재설정 인증코드 검증

### 참고 사항

- swagger에 나와있는 비밀번호 재설정 인증코드 전송 & 검증 api는 연결 후 테스트까지 완료했습니다.

### 스크린 샷

![이메일_찾기](https://github.com/user-attachments/assets/34c2e460-4562-4c37-8520-7557eae3689e)

![비밀번호_찾기](https://github.com/user-attachments/assets/e8664c98-9426-447c-9fa1-64f58c6d0e0c)

## 🔗 연관된 이슈

> closes #280
