### PR TITLE
Feature:223 회원탈퇴 모달 UI 수정 / api 호출 로직 구현

### DIFF
--- a/src/components/common/input/SelectBox.tsx
+++ b/src/components/common/input/SelectBox.tsx
@@ -6,14 +6,26 @@ import { useState } from 'react'
 interface CustomSelectBoxProps {
   defaultLabel: string
   options: { label: string; value: string }[]
+  value?: string | null // 현재 선택된 값
+  onChange?: (value: string) => void // 선택 시 부모에 전달
 }
 
 export default function CustomSelectBox({
   defaultLabel,
   options,
+  value: propValue,
+  onChange,
 }: CustomSelectBoxProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [value, setValue] = useState<string | null>(null)
+  const [internalValue, setInternalValue] = useState<string | null>(null)
+
+  const value = propValue ?? internalValue
+
+  const handleSelect = (val: string) => {
+    setInternalValue(val) // 내부 상태 업데이트
+    onChange?.(val) // 부모 상태 전달
+    setIsOpen(false)
+  }
 
   return (
     <div className="relative w-full">
@@ -33,10 +45,7 @@ export default function CustomSelectBox({
           {options.map((option) => (
             <li
               key={option.value}
-              onClick={() => {
-                setValue(option.value)
-                setIsOpen(false)
-              }}
+              onClick={() => handleSelect(option.value)}
               className="cursor-pointer px-3 py-3 text-sm text-gray-600 hover:bg-gray-50"
             >
               {option.label}

--- a/src/components/common/input/SelectBox.tsx
+++ b/src/components/common/input/SelectBox.tsx
@@ -1,0 +1,49 @@
+import { InputBase } from '@/constants/input-variants'
+import { cn } from '@/utils'
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+
+interface CustomSelectBoxProps {
+  defaultLabel: string
+  options: { label: string; value: string }[]
+}
+
+export default function CustomSelectBox({
+  defaultLabel,
+  options,
+}: CustomSelectBoxProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [value, setValue] = useState<string | null>(null)
+
+  return (
+    <div className="relative w-full">
+      <button
+        type="button"
+        className={cn(
+          InputBase,
+          'flex items-center justify-between px-3 text-gray-800'
+        )}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {value ? options.find((o) => o.value === value)?.label : defaultLabel}
+        <ChevronDown className="text-gray-400" size={20} />
+      </button>
+      {isOpen && (
+        <ul className="absolute left-0 mt-1 w-full rounded border bg-white shadow">
+          {options.map((option) => (
+            <li
+              key={option.value}
+              onClick={() => {
+                setValue(option.value)
+                setIsOpen(false)
+              }}
+              className="cursor-pointer px-3 py-3 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/input/index.ts
+++ b/src/components/common/input/index.ts
@@ -3,5 +3,13 @@ import InputDescription from '@/components/common/input/InputDescription'
 import InputLabel from '@/components/common/input/InputLabel'
 import InputErrorMessage from '@/components/common/input/InputErrorMessage'
 import PasswordInput from '@/components/common/input/PasswordInput'
+import CustomSelectBox from '@/components/common/input/SelectBox'
 
-export { Input, InputDescription, InputLabel, InputErrorMessage, PasswordInput }
+export {
+  Input,
+  InputDescription,
+  InputLabel,
+  InputErrorMessage,
+  PasswordInput,
+  CustomSelectBox,
+}

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -79,7 +79,7 @@ export const Withdrawal = () => {
               <li>2주 후 모든 개인정보가 완전히 삭제됩니다</li>
             </ul>
           </section>
-          <section className="flex flex-col gap-2">
+          <form className="flex flex-col gap-2">
             <InputLabel isRequired>탈퇴 사유</InputLabel>
             <CustomSelectBox
               defaultLabel="탈퇴 사유 선택"
@@ -134,7 +134,7 @@ export const Withdrawal = () => {
                 회원 탈퇴를 위한 동의가 필요합니다
               </InputErrorMessage>
             )}
-          </section>
+          </form>
         </ModalMain>
 
         <ModalFooter className="flex justify-end gap-1">

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -10,13 +10,16 @@ import {
 } from '@/components/common/Modal'
 import { Button } from '@/components'
 import { CircleAlert } from 'lucide-react'
+import { InputLabel, CustomSelectBox } from '@/components/common/input'
+import { InputBase } from '@/constants/input-variants'
+import { cn } from '@/utils'
 
 export const Withdrawal = () => {
   return (
     <Modal>
       {/* 모달 열기 버튼 */}
       <ModalTrigger>
-        <Button variant="danger" size="lg">
+        <Button variant="danger" size="lg" className="whitespace-nowrap">
           회원 탈퇴
         </Button>
       </ModalTrigger>
@@ -24,27 +27,49 @@ export const Withdrawal = () => {
       <ModalContent>
         <ModalHeader>
           <ModalTitle className="flex items-center gap-3">
-            <div className="flex justify-center rounded-full bg-[#FEE2E2] px-3 py-3">
+            <div className="flex justify-center rounded-full bg-[#FEE2E2] px-2 py-2">
               <CircleAlert className="text-danger-600" size="16" />
             </div>
             <span>회원 탈퇴</span>
           </ModalTitle>
         </ModalHeader>
 
-        <ModalMain className="p-6">
-          <div className="border border-[#FECACA] bg-[#FEF2F2] px-8 py-4">
+        <ModalMain className="flex flex-col gap-4 p-6">
+          <section className="border border-[#FECACA] bg-[#FEF2F2] px-6 py-4">
             <p className="flex items-center gap-2 pb-2">
               <CircleAlert className="text-danger-600" size="14" />
               <span className="text-danger-800 text-sm">회원 탈퇴 안내</span>
             </p>
-            <ul className="flex list-disc flex-col gap-1 pb-4 text-xs text-[#B91C1C]">
+            <ul className="flex list-disc flex-col gap-1 px-4 pb-4 text-xs text-[#B91C1C]">
               <li>탈퇴 즉시 서비스 이용이 중단됩니다</li>
               <li>
                 <strong>2주간 계정 복구가 가능</strong>합니다
               </li>
               <li>2주 후 모든 개인정보가 완전히 삭제됩니다</li>
             </ul>
-          </div>
+          </section>
+          <section className="flex flex-col gap-2">
+            <InputLabel isRequired>탈퇴 사유</InputLabel>
+            <CustomSelectBox
+              defaultLabel="탈퇴 사유를 선택해주세요"
+              options={[
+                { label: '서비스 불만족', value: 'dissatisfaction' },
+                { label: '개인정보 우려', value: 'privacy' },
+                { label: '사용 빈도 낮음', value: 'low_usage' },
+                { label: '경쟁 서비스 이용', value: 'competitor' },
+                { label: '기타', value: 'other' },
+              ]}
+            />
+            <InputLabel isRequired>탈퇴 상세 사유</InputLabel>
+            <textarea
+              className={cn(InputBase, 'h-20 resize-none px-3 text-gray-800')}
+              placeholder="탈퇴 사유를 입력해주세요."
+            />
+            <div className="flex gap-2">
+              <input type="checkbox" />
+              <InputLabel isRequired>회원 탈퇴에 동의합니다</InputLabel>
+            </div>
+          </section>
         </ModalMain>
 
         <ModalFooter className="flex justify-end gap-1">

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -53,11 +53,24 @@ export const Withdrawal = () => {
             <CustomSelectBox
               defaultLabel="탈퇴 사유를 선택해주세요"
               options={[
-                { label: '서비스 불만족', value: 'dissatisfaction' },
-                { label: '개인정보 우려', value: 'privacy' },
-                { label: '사용 빈도 낮음', value: 'low_usage' },
-                { label: '경쟁 서비스 이용', value: 'competitor' },
-                { label: '기타', value: 'other' },
+                {
+                  label: '서비스 이용할 시간이 없음',
+                  value: 'NO_LONGER_NEEDED',
+                },
+                { label: '관심이 사라짐', value: 'LACK_OF_INTEREST' },
+                {
+                  label: '서비스를 이용하기가 너무 어려움',
+                  value: 'TOO_DIFFICULT',
+                },
+                { label: '더 좋은 대안을 찾음', value: 'FOUND_BETTER_SERVICE' },
+                { label: '개인정보/보안 우려', value: 'PRIVACY_CONCERNS' },
+                { label: '서비스 품질 불만', value: 'POOR_SERVICE_QUALITY' },
+                { label: '기술적 문제(버그 등)', value: 'TECHNICAL_ISSUES' },
+                {
+                  label: '원하는 콘텐츠나 기능의 부족',
+                  value: 'LACK_OF_CONTENT',
+                },
+                { label: '기타', value: 'OTHER' },
               ]}
             />
             <InputLabel isRequired>탈퇴 상세 사유</InputLabel>

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/utils'
 import { useState } from 'react'
 import useWithdrawUser from '@/hooks/api/auth/useWithdrawUser'
 import { WithdrawalReasonEnum } from '@/types/api-request-types/auth-request-types'
+import { withdrawalReason } from '@/constants/withdrawal-reasons'
 
 export const Withdrawal = () => {
   const [reason, setReason] = useState<string | null>(null)
@@ -83,26 +84,7 @@ export const Withdrawal = () => {
             <InputLabel isRequired>탈퇴 사유</InputLabel>
             <CustomSelectBox
               defaultLabel="탈퇴 사유 선택"
-              options={[
-                {
-                  label: '서비스 이용할 시간이 없음',
-                  value: 'NO_LONGER_NEEDED',
-                },
-                { label: '관심이 사라짐', value: 'LACK_OF_INTEREST' },
-                {
-                  label: '서비스를 이용하기가 너무 어려움',
-                  value: 'TOO_DIFFICULT',
-                },
-                { label: '더 좋은 대안을 찾음', value: 'FOUND_BETTER_SERVICE' },
-                { label: '개인정보/보안 우려', value: 'PRIVACY_CONCERNS' },
-                { label: '서비스 품질 불만', value: 'POOR_SERVICE_QUALITY' },
-                { label: '기술적 문제(버그 등)', value: 'TECHNICAL_ISSUES' },
-                {
-                  label: '원하는 콘텐츠나 기능의 부족',
-                  value: 'LACK_OF_CONTENT',
-                },
-                { label: '기타', value: 'OTHER' },
-              ]}
+              options={withdrawalReason}
               value={reason}
               onChange={(val) => setReason(val as WithdrawalReasonEnum)}
             />

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -10,11 +10,34 @@ import {
 } from '@/components/common/Modal'
 import { Button } from '@/components'
 import { CircleAlert } from 'lucide-react'
-import { InputLabel, CustomSelectBox } from '@/components/common/input'
+import {
+  InputLabel,
+  CustomSelectBox,
+  InputErrorMessage,
+} from '@/components/common/input'
 import { InputBase } from '@/constants/input-variants'
 import { cn } from '@/utils'
+import { useState } from 'react'
+import useWithdrawUser from '@/hooks/api/auth/useWithdrawUser'
+import { WithdrawalReasonEnum } from '@/types/api-request-types/auth-request-types'
 
 export const Withdrawal = () => {
+  const [reason, setReason] = useState<string | null>(null)
+  const [detail, setDetail] = useState<string>('')
+  const [agree, setAgree] = useState(false)
+  const withdrawMutation = useWithdrawUser()
+  const [validation, setValidation] = useState(false)
+
+  const handleSubmit = () => {
+    if (!reason || !detail || !agree) {
+      setValidation(true)
+    }
+    withdrawMutation.mutate({
+      reason: reason as WithdrawalReasonEnum,
+      reason_detail: detail,
+    })
+  }
+
   return (
     <Modal>
       {/* 모달 열기 버튼 */}
@@ -51,7 +74,7 @@ export const Withdrawal = () => {
           <section className="flex flex-col gap-2">
             <InputLabel isRequired>탈퇴 사유</InputLabel>
             <CustomSelectBox
-              defaultLabel="탈퇴 사유를 선택해주세요"
+              defaultLabel="탈퇴 사유 선택"
               options={[
                 {
                   label: '서비스 이용할 시간이 없음',
@@ -72,16 +95,38 @@ export const Withdrawal = () => {
                 },
                 { label: '기타', value: 'OTHER' },
               ]}
+              value={reason ?? null}
+              onChange={(val) => setReason(val as WithdrawalReasonEnum)}
             />
+            {(validation && !reason) ?? (
+              <InputErrorMessage> 탈퇴 사유를 선택해주세요 </InputErrorMessage>
+            )}
             <InputLabel isRequired>탈퇴 상세 사유</InputLabel>
             <textarea
               className={cn(InputBase, 'h-20 resize-none px-3 text-gray-800')}
-              placeholder="탈퇴 사유를 입력해주세요."
+              placeholder="탈퇴 상세 사유를 입력해주세요."
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
             />
+            {(validation && !detail) ?? (
+              <InputErrorMessage>
+                {' '}
+                탈퇴 상세 사유를 입력해주세요{' '}
+              </InputErrorMessage>
+            )}
             <div className="flex gap-2">
-              <input type="checkbox" />
+              <input
+                type="checkbox"
+                checked={agree}
+                onChange={(e) => setAgree(e.target.checked)}
+              />
               <InputLabel isRequired>회원 탈퇴에 동의합니다</InputLabel>
             </div>
+            {(validation && !agree) ?? (
+              <InputErrorMessage>
+                회원 탈퇴를 위한 동의가 필요합니다
+              </InputErrorMessage>
+            )}
           </section>
         </ModalMain>
 
@@ -89,7 +134,9 @@ export const Withdrawal = () => {
           <ModalClose>
             <Button variant="outline">취소</Button>
           </ModalClose>
-          <Button variant="danger">회원 탈퇴</Button>
+          <Button variant="danger" onClick={handleSubmit}>
+            회원 탈퇴
+          </Button>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/components/my-page/my-info/Withdrawal.tsx
+++ b/src/components/my-page/my-info/Withdrawal.tsx
@@ -25,17 +25,25 @@ export const Withdrawal = () => {
   const [reason, setReason] = useState<string | null>(null)
   const [detail, setDetail] = useState<string>('')
   const [agree, setAgree] = useState(false)
-  const withdrawMutation = useWithdrawUser()
   const [validation, setValidation] = useState(false)
+  const withdrawMutation = useWithdrawUser()
 
   const handleSubmit = () => {
     if (!reason || !detail || !agree) {
       setValidation(true)
+      return
     }
     withdrawMutation.mutate({
       reason: reason as WithdrawalReasonEnum,
       reason_detail: detail,
     })
+  }
+
+  const handleCancel = () => {
+    setReason(null)
+    setDetail('')
+    setAgree(false)
+    setValidation(false)
   }
 
   return (
@@ -95,10 +103,10 @@ export const Withdrawal = () => {
                 },
                 { label: '기타', value: 'OTHER' },
               ]}
-              value={reason ?? null}
+              value={reason}
               onChange={(val) => setReason(val as WithdrawalReasonEnum)}
             />
-            {(validation && !reason) ?? (
+            {validation && !reason && (
               <InputErrorMessage> 탈퇴 사유를 선택해주세요 </InputErrorMessage>
             )}
             <InputLabel isRequired>탈퇴 상세 사유</InputLabel>
@@ -108,10 +116,9 @@ export const Withdrawal = () => {
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
             />
-            {(validation && !detail) ?? (
+            {validation && !detail && (
               <InputErrorMessage>
-                {' '}
-                탈퇴 상세 사유를 입력해주세요{' '}
+                탈퇴 상세 사유를 입력해주세요
               </InputErrorMessage>
             )}
             <div className="flex gap-2">
@@ -122,7 +129,7 @@ export const Withdrawal = () => {
               />
               <InputLabel isRequired>회원 탈퇴에 동의합니다</InputLabel>
             </div>
-            {(validation && !agree) ?? (
+            {validation && !agree && (
               <InputErrorMessage>
                 회원 탈퇴를 위한 동의가 필요합니다
               </InputErrorMessage>
@@ -132,7 +139,9 @@ export const Withdrawal = () => {
 
         <ModalFooter className="flex justify-end gap-1">
           <ModalClose>
-            <Button variant="outline">취소</Button>
+            <Button variant="outline" onClick={handleCancel}>
+              취소
+            </Button>
           </ModalClose>
           <Button variant="danger" onClick={handleSubmit}>
             회원 탈퇴

--- a/src/constants/withdrawal-reasons.ts
+++ b/src/constants/withdrawal-reasons.ts
@@ -1,0 +1,48 @@
+import { WithdrawalReasonEnum } from '@/types/api-request-types/auth-request-types'
+
+interface withdrawalReasonProps {
+  label: string
+  value: WithdrawalReasonEnum
+}
+
+const {
+  NO_LONGER_NEEDED,
+  LACK_OF_INTEREST,
+  TOO_DIFFICULT,
+  FOUND_BETTER_SERVICE,
+  PRIVACY_CONCERNS,
+  POOR_SERVICE_QUALITY,
+  TECHNICAL_ISSUES,
+  LACK_OF_CONTENT,
+  OTHER,
+} = WithdrawalReasonEnum
+
+export const withdrawalReason: withdrawalReasonProps[] = [
+  {
+    label: '서비스 이용할 시간이 없음',
+    value: NO_LONGER_NEEDED,
+  },
+  { label: '관심이 사라짐', value: LACK_OF_INTEREST },
+  {
+    label: '서비스를 이용하기가 너무 어려움',
+    value: TOO_DIFFICULT,
+  },
+  {
+    label: '더 좋은 대안을 찾음',
+    value: FOUND_BETTER_SERVICE,
+  },
+  { label: '개인정보/보안 우려', value: PRIVACY_CONCERNS },
+  {
+    label: '서비스 품질 불만',
+    value: POOR_SERVICE_QUALITY,
+  },
+  {
+    label: '기술적 문제(버그 등)',
+    value: TECHNICAL_ISSUES,
+  },
+  {
+    label: '원하는 콘텐츠나 기능의 부족',
+    value: LACK_OF_CONTENT,
+  },
+  { label: '기타', value: OTHER },
+] as const

--- a/src/hooks/api/auth/useWithdrawUser.ts
+++ b/src/hooks/api/auth/useWithdrawUser.ts
@@ -16,7 +16,9 @@ export default function useWithdrawUser() {
   return useMutation<void, AxiosError, WithdrawalRequest>({
     mutationKey: ['user', 'withdraw'],
     mutationFn: async (payload) => {
-      return await api.post(`${API_BASE_URL}/auth/withdraw`, payload)
+      return await api.delete(`${API_BASE_URL}/auth/withdraw`, {
+        data: payload,
+      })
     },
     onSuccess: () => {
       triggerToast('success', '회원 탈퇴가 완료되었습니다 ✅')

--- a/src/hooks/api/auth/useWithdrawUser.ts
+++ b/src/hooks/api/auth/useWithdrawUser.ts
@@ -1,0 +1,40 @@
+import { API_BASE_URL } from '@/constants/url-constants'
+import api from '@/utils/axios'
+import useToast from '@/hooks/useToast'
+import { useMutation } from '@tanstack/react-query'
+import { useLoginStore } from '@/store/useLoginStore'
+import { clearAccessToken } from '@/utils'
+import type { AxiosError } from 'axios'
+import type { WithdrawalRequest } from '@/types/api-request-types/auth-request-types'
+import { useNavigate } from 'react-router'
+
+export default function useWithdrawUser() {
+  const { triggerToast } = useToast()
+  const { setIsLoggedIn } = useLoginStore()
+  const navigate = useNavigate()
+
+  return useMutation<void, AxiosError, WithdrawalRequest>({
+    mutationKey: ['user', 'withdraw'],
+    mutationFn: async (payload) => {
+      return await api.delete(`${API_BASE_URL}/users/me`, {
+        data: payload,
+      })
+    },
+    onSuccess: () => {
+      triggerToast('success', '회원 탈퇴가 완료되었습니다 ✅')
+      clearAccessToken()
+      setIsLoggedIn(false)
+      navigate('/')
+    },
+    onError: (error) => {
+      const status = error.response?.status
+      if (status === 400) {
+        triggerToast('error', '잘못된 요청입니다')
+      } else if (status === 401) {
+        triggerToast('error', '로그인이 필요합니다')
+      } else {
+        triggerToast('error', '잠시 후 다시 시도해주세요')
+      }
+    },
+  })
+}

--- a/src/hooks/api/auth/useWithdrawUser.ts
+++ b/src/hooks/api/auth/useWithdrawUser.ts
@@ -16,7 +16,7 @@ export default function useWithdrawUser() {
   return useMutation<void, AxiosError, WithdrawalRequest>({
     mutationKey: ['user', 'withdraw'],
     mutationFn: async (payload) => {
-      return await api.delete(`${API_BASE_URL}/users/me`, {
+      return await api.delete(`${API_BASE_URL}/users/delete`, {
         data: payload,
       })
     },
@@ -26,6 +26,7 @@ export default function useWithdrawUser() {
       setIsLoggedIn(false)
       navigate('/')
     },
+
     onError: (error) => {
       const status = error.response?.status
       if (status === 400) {

--- a/src/hooks/api/auth/useWithdrawUser.ts
+++ b/src/hooks/api/auth/useWithdrawUser.ts
@@ -16,9 +16,7 @@ export default function useWithdrawUser() {
   return useMutation<void, AxiosError, WithdrawalRequest>({
     mutationKey: ['user', 'withdraw'],
     mutationFn: async (payload) => {
-      return await api.post(`${API_BASE_URL}/auth/withdraw`, {
-        data: payload,
-      })
+      return await api.post(`${API_BASE_URL}/auth/withdraw`, payload)
     },
     onSuccess: () => {
       triggerToast('success', '회원 탈퇴가 완료되었습니다 ✅')

--- a/src/hooks/api/auth/useWithdrawUser.ts
+++ b/src/hooks/api/auth/useWithdrawUser.ts
@@ -16,7 +16,7 @@ export default function useWithdrawUser() {
   return useMutation<void, AxiosError, WithdrawalRequest>({
     mutationKey: ['user', 'withdraw'],
     mutationFn: async (payload) => {
-      return await api.delete(`${API_BASE_URL}/users/delete`, {
+      return await api.post(`${API_BASE_URL}/auth/withdraw`, {
         data: payload,
       })
     },

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -1,3 +1,5 @@
+import { bigint } from 'zod'
+
 export interface UserLogin {
   email: string
   password: string
@@ -63,4 +65,22 @@ export interface UserResetPasswordVerify {
 
 export interface UserResetPassword {
   password: string
+}
+// ERD 참조하여 생성
+export interface Withdrawals {
+  id: bigint
+  userId: bigint
+  reason: WithdrawalReasonEnum
+  reason_detail: string
+  dueDate: Date
+  createdAt: Date
+  updatedAt: Date
+}
+
+export enum WithdrawalReasonEnum {
+  dissatisfaction = 'dissatisfaction',
+  privacy = 'privacy',
+  lowUsage = 'low_usage',
+  competitor = 'competitor',
+  other = 'other',
 }

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -40,6 +40,7 @@ export interface UpdateUserInfoRequest {
   phoneNumber: string
 }
 
+<<<<<<< HEAD
 export interface UserKakaoLogin {
   code: string
 }
@@ -67,6 +68,8 @@ export interface UserResetPassword {
   password: string
 }
 // ERD 참조하여 생성
+=======
+>>>>>>> 91a6563 (♻️ Refactor: 탈퇴 사유 enum을 ERD에 맞춰서 수정, UI도 수정 (#223))
 export interface Withdrawals {
   id: bigint
   userId: bigint
@@ -78,9 +81,24 @@ export interface Withdrawals {
 }
 
 export enum WithdrawalReasonEnum {
-  dissatisfaction = 'dissatisfaction',
-  privacy = 'privacy',
-  lowUsage = 'low_usage',
-  competitor = 'competitor',
-  other = 'other',
+  NO_LONGER_NEEDED = 'NO_LONGER_NEEDED',
+  LACK_OF_INTEREST = 'LACK_OF_INTEREST',
+  TOO_DIFFICULT = 'TOO_DIFFICULT',
+  FOUND_BETTER_SERVICE = 'FOUND_BETTER_SERVICE',
+  PRIVACY_CONCERNS = 'PRIVACY_CONCERNS',
+  POOR_SERVICE_QUALITY = 'POOR_SERVICE_QUALITY',
+  TECHNICAL_ISSUES = 'TECHNICAL_ISSUES',
+  LACK_OF_CONTENT = 'LACK_OF_CONTENT',
+  OTHER = 'OTHER',
 }
+
+// 백엔드 ERD 참조
+// NO_LONGER_NEEDED // 서비스 이용할 시간이 없음
+// LACK_OF_INTEREST // 관심이 사라짐
+// TOO_DIFFICULT // 서비스를 이용하기가 너무 어려움
+// FOUND_BETTER_SERVICE // 더 좋은 대안을 찾음
+// PRIVACY_CONCERNS // 개인정보/보안 우려
+// POOR_SERVICE_QUALITY // 서비스 품질 불만
+// TECHNICAL_ISSUES // 기술적 문제(버그 등)
+// LACK_OF_CONTENT // 원하는 콘텐츠나 기능의 부족
+// OTHER // 기타

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -1,5 +1,3 @@
-import { bigint } from 'zod'
-
 export interface UserLogin {
   email: string
   password: string
@@ -40,7 +38,6 @@ export interface UpdateUserInfoRequest {
   phoneNumber: string
 }
 
-<<<<<<< HEAD
 export interface UserKakaoLogin {
   code: string
 }
@@ -68,16 +65,9 @@ export interface UserResetPassword {
   password: string
 }
 // ERD 참조하여 생성
-=======
->>>>>>> 91a6563 (♻️ Refactor: 탈퇴 사유 enum을 ERD에 맞춰서 수정, UI도 수정 (#223))
-export interface Withdrawals {
-  id: bigint
-  userId: bigint
+export interface WithdrawalRequest {
   reason: WithdrawalReasonEnum
   reason_detail: string
-  dueDate: Date
-  createdAt: Date
-  updatedAt: Date
 }
 
 export enum WithdrawalReasonEnum {


### PR DESCRIPTION
## 🚀 PR 요약

> 회원탈퇴 모달의 UI를 수정하고, API 호출 로직을 포함한 추가 로직들을 구현했습니다.

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

### 작업 사항

- select 태그를 대체할 select 컴포넌트 생성 후 적용
- 회원 탈퇴관련 타입 정의
- api 호출 훅 생성
- 필드 미입력시 에러메세지 추가, 탈퇴하기 버튼 클릭시 노출되게끔 상태로직 추가
- 취소 버튼 클릭시 입력필드, 확인상태관리 초기화 로직 추가

### 참고 사항

- 내 정보 수정 / 비밀번호 변경 / 회원탈퇴 전부 404 에러 뜨고있음. 엔드포인트 확인 필요.
- 메서드와 엔드포인트, payload flat 구조로 수정 후 정상작동 확인!
- 메서드를 delete로 하는 게 맞는거 같다라는 백엔드 동길님의 의견 수렴하여 다시 delete 메서드와 { data: payload } 형태로 복구
=> axios.post의 2번째 인자는 body / axios.delete의 2번째 인자는 config 객체.
때문에 post 메서드일때는 payload만 작성하여 flat 구조로 전달
하지만 delete 메서드일때는 {data: payload} 형태로 객체 구조로 전달

- 다시 로그인 시도 시 복구안내 모달로 이어지지는 않는 것을 확인...
- 백엔드 팀에게 상황전달 완료. 해결 후 안내받을 예정

### 스크린 샷


https://github.com/user-attachments/assets/efdc0ab0-db7e-4343-8ded-d6acbf252f85

탈퇴 후 로그인 시도시 이미지 첨부
<img width="1299" height="1159" alt="탈퇴 후 로그인" src="https://github.com/user-attachments/assets/31b9219b-97a2-442e-8bea-64f9cb0716a5" />

## 🔗 연관된 이슈

> closes #223 
