### PR TITLE
Fix:287 내정보 수정, 비밀번호 변경 메서드, 엔드포인트 픽스 / Feature:291 이미지 업로드 로직 구현

### DIFF
--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/schemas/form-schema/info-update-schema'
 import { useVerificationCode } from '@/hooks'
 import { cn } from '@/utils'
+import { useEffect } from 'react'
 
 export const InfoUpdateForm = () => {
   const { data: userInfo } = useUserInformation()
@@ -30,17 +31,28 @@ export const InfoUpdateForm = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors },
     getValues,
     setError,
+    reset,
   } = useForm<InfoUpdateType>({
     mode: 'onChange',
     resolver: zodResolver(InfoUpdateSchema),
     defaultValues: {
-      nickname: userInfo?.nickname ?? '',
-      phoneNumber: userInfo?.phoneNumber ?? '',
+      nickname: '',
+      phoneNumber: '',
     },
   })
+
+  // ✅ userInfo 들어오면 form 값 초기화
+  useEffect(() => {
+    if (userInfo) {
+      reset({
+        nickname: userInfo.nickname ?? '',
+        phoneNumber: userInfo.phoneNumber ?? '',
+      })
+    }
+  }, [userInfo, reset])
 
   const phoneNumber = getValues('phoneNumber')
 
@@ -53,6 +65,7 @@ export const InfoUpdateForm = () => {
     }
     handleCodeSend('phoneNumber', phoneNumber)
   }
+
   const handleVerifyButtonClick = () => {
     const verificationCode = getValues('infoUpdateVerificationCode')
     if (!verificationCode) {
@@ -148,14 +161,12 @@ export const InfoUpdateForm = () => {
           <div className="flex flex-col gap-2">
             <div className="flex gap-2">
               <Input
-                disabled={!isCodeSent.phoneNumber}
                 id="infoUpdateVerificationCode"
                 {...register('infoUpdateVerificationCode')}
                 placeholder="인증코드 6자리 입력"
                 readOnly={isCodeVerified.phoneNumber}
                 className={cn(
-                  isCodeVerified.phoneNumber &&
-                    'disabled:bg-white disabled:text-black'
+                  isCodeVerified.phoneNumber && 'bg-gray-100 text-gray-500'
                 )}
               />
               <Button
@@ -184,7 +195,10 @@ export const InfoUpdateForm = () => {
         <Button
           variant="primary"
           type="submit"
-          disabled={!isValid || !isCodeVerified.phoneNumber}
+          // isValid 대신 에러 유무 + 인증 완료 여부로 체크
+          disabled={
+            Object.keys(errors).length > 0 || !isCodeVerified.phoneNumber
+          }
         >
           변경하기
         </Button>

--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -221,7 +221,8 @@ export const InfoUpdateForm = () => {
           type="submit"
           // isValid 대신 에러 유무 + 인증 완료 여부로 체크
           disabled={
-            Object.keys(errors).length > 0 || !isCodeVerified.phoneNumber
+            Object.keys(errors).filter((key) => key !== 'root').length > 0 ||
+            !isCodeVerified.phoneNumber
           }
         >
           변경하기

--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -101,19 +101,13 @@ export const InfoUpdateForm = () => {
     try {
       const url = await uploadImage(file)
       setProfileImageUrl(url)
-    } catch (err) {
+    } catch {
       setError('root', { message: '이미지 업로드에 실패했습니다' })
     }
   }
 
   // ✅ 최종 제출
   const onSubmit = (values: InfoUpdateType) => {
-    console.log('제출 payload 확인 👉', {
-      nickname: values.nickname,
-      phoneNumber: values.phoneNumber,
-      verificationCode: values.infoUpdateVerificationCode,
-    })
-
     if (!isCodeVerified.phoneNumber) {
       setError('infoUpdateVerificationCode', {
         message: '휴대폰 번호 인증을 완료해주세요',

--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -108,6 +108,12 @@ export const InfoUpdateForm = () => {
 
   // ✅ 최종 제출
   const onSubmit = (values: InfoUpdateType) => {
+    console.log('제출 payload 확인 👉', {
+      nickname: values.nickname,
+      phoneNumber: values.phoneNumber,
+      verificationCode: values.infoUpdateVerificationCode,
+    })
+
     if (!isCodeVerified.phoneNumber) {
       setError('infoUpdateVerificationCode', {
         message: '휴대폰 번호 인증을 완료해주세요',
@@ -119,6 +125,7 @@ export const InfoUpdateForm = () => {
       nickname: values.nickname,
       phoneNumber: values.phoneNumber,
       profileImageUrl: profileImageUrl ?? '',
+      verificationCode: values.infoUpdateVerificationCode,
     })
   }
 

--- a/src/components/my-page/my-info/InfoUpdateForm.tsx
+++ b/src/components/my-page/my-info/InfoUpdateForm.tsx
@@ -15,7 +15,8 @@ import {
 } from '@/schemas/form-schema/info-update-schema'
 import { useVerificationCode } from '@/hooks'
 import { cn } from '@/utils'
-import { useEffect } from 'react'
+import { useEffect, useState, type ChangeEvent } from 'react'
+import useImageUpload from '@/hooks/useImageUpload'
 
 export const InfoUpdateForm = () => {
   const { data: userInfo } = useUserInformation()
@@ -27,6 +28,8 @@ export const InfoUpdateForm = () => {
     handleCodeSend,
     handleCodeVerify,
   } = useVerificationCode()
+  const [previewImage, setPreviewImage] = useState<string | null>(null)
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null)
 
   const {
     register,
@@ -44,13 +47,15 @@ export const InfoUpdateForm = () => {
     },
   })
 
-  // ✅ userInfo 들어오면 form 값 초기화
+  const { uploadImage } = useImageUpload()
+
   useEffect(() => {
     if (userInfo) {
       reset({
         nickname: userInfo.nickname ?? '',
         phoneNumber: userInfo.phoneNumber ?? '',
       })
+      setProfileImageUrl(userInfo.profileImageUrl ?? null)
     }
   }, [userInfo, reset])
 
@@ -85,6 +90,21 @@ export const InfoUpdateForm = () => {
       close()
     },
   })
+  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    // 미리보기 업데이트
+    setPreviewImage(URL.createObjectURL(file))
+
+    // 업로드 -> url 받아오기
+    try {
+      const url = await uploadImage(file)
+      setProfileImageUrl(url)
+    } catch (err) {
+      setError('root', { message: '이미지 업로드에 실패했습니다' })
+    }
+  }
 
   // ✅ 최종 제출
   const onSubmit = (values: InfoUpdateType) => {
@@ -98,6 +118,7 @@ export const InfoUpdateForm = () => {
     updateUserInfo.mutate({
       nickname: values.nickname,
       phoneNumber: values.phoneNumber,
+      profileImageUrl: profileImageUrl ?? '',
     })
   }
 
@@ -108,11 +129,13 @@ export const InfoUpdateForm = () => {
       <ModalMain className="flex flex-col gap-6">
         {/* 프로필 이미지 */}
         <label className="flex cursor-pointer flex-col items-center gap-4">
-          <Avatar
-            size="3xl"
-            state="none"
-            src={userInfo.profileImageUrl ?? undefined}
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageChange}
           />
+          <Avatar size="3xl" state="none" src={previewImage ?? undefined} />
           <span className="text-primary-600 text-sm">프로필 사진 변경</span>
         </label>
 

--- a/src/hooks/api/auth/useChangePassword.ts
+++ b/src/hooks/api/auth/useChangePassword.ts
@@ -14,13 +14,13 @@ export default function useChangePassword(
     ...options,
     mutationKey: ['user'],
     mutationFn: async (payload) => {
-      const verifyResponse = await api.get(`${API_BASE_URL}/users/me`, {
+      const verifyResponse = await api.get(`${API_BASE_URL}/info`, {
         params: { password: payload.currentPassword },
       })
       if (verifyResponse.data !== payload.currentPassword) {
         throw new Error('현재 비밀번호가 올바르지 않습니다.')
       }
-      return api.put(`${API_BASE_URL}/user`, {
+      return api.patch(`${API_BASE_URL}/info/edit`, {
         password: payload.newPassword,
       })
     },

--- a/src/hooks/api/auth/useChangePassword.ts
+++ b/src/hooks/api/auth/useChangePassword.ts
@@ -14,13 +14,13 @@ export default function useChangePassword(
     ...options,
     mutationKey: ['user'],
     mutationFn: async (payload) => {
-      const verifyResponse = await api.get(`${API_BASE_URL}/info`, {
+      const verifyResponse = await api.get(`${API_BASE_URL}/info/`, {
         params: { password: payload.currentPassword },
       })
       if (verifyResponse.data !== payload.currentPassword) {
         throw new Error('현재 비밀번호가 올바르지 않습니다.')
       }
-      return api.patch(`${API_BASE_URL}/info/edit`, {
+      return api.patch(`${API_BASE_URL}/info/edit/`, {
         password: payload.newPassword,
       })
     },

--- a/src/hooks/api/auth/useChangePassword.ts
+++ b/src/hooks/api/auth/useChangePassword.ts
@@ -14,13 +14,7 @@ export default function useChangePassword(
     ...options,
     mutationKey: ['user'],
     mutationFn: async (payload) => {
-      const verifyResponse = await api.get(`${API_BASE_URL}/info/`, {
-        params: { password: payload.currentPassword },
-      })
-      if (verifyResponse.data !== payload.currentPassword) {
-        throw new Error('현재 비밀번호가 올바르지 않습니다.')
-      }
-      return api.patch(`${API_BASE_URL}/info/edit/`, {
+      await api.patch(`${API_BASE_URL}/info/edit/`, {
         password: payload.newPassword,
       })
     },

--- a/src/hooks/api/auth/useUpdateUserInfo.ts
+++ b/src/hooks/api/auth/useUpdateUserInfo.ts
@@ -15,11 +15,17 @@ export default function useUpdateUserInfo(
   return useMutation<unknown, AxiosError, UpdateUserInfoRequest>({
     ...options,
     mutationKey: ['user', 'update-info'],
-    mutationFn: async ({ nickname, phoneNumber, profileImageUrl }) => {
-      return await api.patch(`${API_BASE_URL}/info/edit`, {
+    mutationFn: async ({
+      nickname,
+      phoneNumber,
+      profileImageUrl,
+      verificationCode,
+    }) => {
+      return await api.patch(`${API_BASE_URL}/info/edit/`, {
         nickname,
         phone_number: phoneNumber,
         profile_image_url: profileImageUrl,
+        verification_code: verificationCode,
       })
     },
     onSuccess: async (_, __, context) => {

--- a/src/hooks/api/auth/useUpdateUserInfo.ts
+++ b/src/hooks/api/auth/useUpdateUserInfo.ts
@@ -15,10 +15,11 @@ export default function useUpdateUserInfo(
   return useMutation<unknown, AxiosError, UpdateUserInfoRequest>({
     ...options,
     mutationKey: ['user', 'update-info'],
-    mutationFn: async ({ nickname, phoneNumber }) => {
+    mutationFn: async ({ nickname, phoneNumber, profileImageUrl }) => {
       return await api.patch(`${API_BASE_URL}/info/edit`, {
         nickname,
         phone_number: phoneNumber,
+        profile_image_url: profileImageUrl,
       })
     },
     onSuccess: async (_, __, context) => {

--- a/src/hooks/api/auth/useUpdateUserInfo.ts
+++ b/src/hooks/api/auth/useUpdateUserInfo.ts
@@ -16,7 +16,7 @@ export default function useUpdateUserInfo(
     ...options,
     mutationKey: ['user', 'update-info'],
     mutationFn: async ({ nickname, phoneNumber }) => {
-      return await api.put(`${API_BASE_URL}/users/me`, {
+      return await api.patch(`${API_BASE_URL}/info/edit`, {
         nickname,
         phone_number: phoneNumber,
       })

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import api from '@/utils/axios'
+import { API_BASE_URL } from '@/constants/url-constants'
+
+export default function useImageUpload() {
+  const [isUploading, setIsUploading] = useState(false)
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      setIsUploading(true)
+      const res = await api.post<{ url: string }>(
+        `${API_BASE_URL}/upload/image`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
+      )
+      return res.data.url
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  return { uploadImage, isUploading }
+}

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -12,7 +12,7 @@ export default function useImageUpload() {
     try {
       setIsUploading(true)
       const res = await api.post<{ url: string }>(
-        `${API_BASE_URL}/upload/image`,
+        `${API_BASE_URL}/info/edit`,
         formData,
         { headers: { 'Content-Type': 'multipart/form-data' } }
       )

--- a/src/schemas/form-schema/info-update-schema.ts
+++ b/src/schemas/form-schema/info-update-schema.ts
@@ -5,8 +5,9 @@ import { signupSchema } from './signup-schema'
 const InfoUpdateSchema = z.object({
   nickname: signupSchema.shape.nickname,
   phoneNumber: signupSchema.shape.phoneNumber,
-  infoUpdateVerificationCode:
-    signupSchema.shape.verificationCode.shape.phoneNumber,
+  infoUpdateVerificationCode: z
+    .string()
+    .min(6, '인증번호 6자리를 입력해주세요'),
 })
 
 type InfoUpdateType = z.infer<typeof InfoUpdateSchema>

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -36,6 +36,7 @@ export interface UserPhoneVerify {
 export interface UpdateUserInfoRequest {
   nickname: string
   phoneNumber: string
+  profileImageUrl: string
 }
 
 export interface UserKakaoLogin {

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -37,6 +37,7 @@ export interface UpdateUserInfoRequest {
   nickname: string
   phoneNumber: string
   profileImageUrl: string
+  verificationCode: string
 }
 
 export interface UserKakaoLogin {


### PR DESCRIPTION
## 🚀 PR 요약

> 정보 수정 부분들의 버그나 메서드,엔드포인트 맞지않는 부분들을 픽스했습니다.
> 이미지 업로드 로직도 추가했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 내 정보 수정 UI 호출 방식 수정
- 내 정보 수정 메서드, 엔드포인트 수정
- 비밀번호 변경 메서드, 엔드포인트 수정
- 내 정보 수정에 이미지 업로드 로직 추가

### 참고 사항

- 로그인 정상화 후 테스트 한 다음 리뷰요청예정.
- 버그 픽스하다가 이미지 업로드 구현하기 전 브랜치 분리를 깜빡함..
- 테스트 결과 프로필 수정 요청 바디 형태에 password가 포함되어 있어 미작동(401)
- 비밀번호 변경 정상작동 확인

### 스크린 샷

> closes #287 
> closes #291 