### PR TITLE
Design: Suspense fallback에 spinner 적용

### DIFF
--- a/src/components/auth/common/AuthStep.tsx
+++ b/src/components/auth/common/AuthStep.tsx
@@ -18,7 +18,7 @@ function AuthStepDot({
   return (
     <div
       className={cn(
-        'flex size-8 items-center justify-center rounded-full bg-gray-200 text-gray-500 transition-colors duration-200 ease-out',
+        'flex size-8 items-center justify-center rounded-full bg-gray-200 text-gray-500 transition-colors duration-300 ease-out',
         isStepReached(stepIndex, currentStep) && 'bg-primary-500 text-white',
         isFinished(currentStep) && 'bg-success-500 text-white'
       )}
@@ -38,7 +38,7 @@ function AuthStepLine({
   return (
     <div
       className={cn(
-        'h-1 flex-1 rounded-sm bg-gray-200 transition-colors duration-200 ease-out',
+        'h-1 flex-1 rounded-sm bg-gray-200 transition-colors duration-300 ease-out',
         isStepReached(stepIndex, currentStep) && 'bg-primary-500',
         isFinished(currentStep) && 'bg-success-500'
       )}

--- a/src/components/common/Spinner.tsx
+++ b/src/components/common/Spinner.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/utils'
+import type { ComponentProps } from 'react'
+
+function Spinner({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export default Spinner

--- a/src/components/common/state/BaseState.tsx
+++ b/src/components/common/state/BaseState.tsx
@@ -30,18 +30,6 @@ function BaseStateIcon({
   )
 }
 
-function BaseStateSpinner({ className, ...props }: ComponentProps<'div'>) {
-  return (
-    <div
-      className={cn(
-        'border-primary-500 animate-loading-state size-12 rounded-full border-b-2 border-solid',
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
 interface BaseStateContentProps extends ComponentProps<'div'> {
   title: string
   description: string
@@ -102,10 +90,4 @@ function BaseStateWrapper({ className, children }: ComponentProps<'div'>) {
   )
 }
 
-export {
-  BaseStateIcon,
-  BaseStateSpinner,
-  BaseStateContent,
-  BaseStateButton,
-  BaseStateWrapper,
-}
+export { BaseStateIcon, BaseStateContent, BaseStateButton, BaseStateWrapper }

--- a/src/components/common/state/LoadingState.tsx
+++ b/src/components/common/state/LoadingState.tsx
@@ -1,9 +1,6 @@
 import type { ComponentProps } from 'react'
-import {
-  BaseStateContent,
-  BaseStateSpinner,
-  BaseStateWrapper,
-} from './BaseState'
+import { BaseStateContent, BaseStateWrapper } from './BaseState'
+import { Spinner } from '@/components'
 
 function LoadingState({
   className,
@@ -11,7 +8,7 @@ function LoadingState({
 }: ComponentProps<typeof BaseStateWrapper>) {
   return (
     <BaseStateWrapper className={className} {...props}>
-      <BaseStateSpinner />
+      <Spinner />
       <BaseStateContent
         title="데이터를 불러오고 있습니다"
         description="잠시만 기다려주세요..."

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -18,6 +18,7 @@ import Notification from '@/components/notification/Notification'
 import Dropdown from '@/components/common/Dropdown'
 import EmptyDataState from '@/components/common/state/EmptyDataState'
 import UserInfoSkeleton from '@/components/common/skeleton/UserInfoSkeleton'
+import Spinner from '@/components/common/Spinner'
 
 export {
   Badge,
@@ -39,4 +40,5 @@ export {
   Dropdown,
   EmptyDataState,
   UserInfoSkeleton,
+  Spinner,
 }

--- a/src/pages/auth/FindEmail.tsx
+++ b/src/pages/auth/FindEmail.tsx
@@ -8,6 +8,7 @@ import { lazy, Suspense, useState } from 'react'
 import FindEmailFirstStep from '@/components/auth/find-email/FindEmailFirstStep'
 import { InputFieldColStyle } from '@/constants/auth-variants'
 import { cn } from '@/utils'
+import { Spinner } from '@/components'
 
 const FindEmailSecondStep = lazy(
   () => import('@/components/auth/find-email/FindEmailSecondStep')
@@ -17,6 +18,8 @@ const FindEmailThirdStep = lazy(
 )
 
 const FIND_EMAIL_STEP_LIST = ['정보입력', '휴대폰인증', '결과확인']
+
+const STEP_WRAPPER_HEIGHT = 366
 
 function FindEmail() {
   const [currentStep, setCurrentStep] = useState(1)
@@ -54,7 +57,16 @@ function FindEmail() {
         />
       )}
       {currentStep === 2 && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense
+          fallback={
+            <div
+              className="flex flex-col items-center justify-center"
+              style={{ height: STEP_WRAPPER_HEIGHT }}
+            >
+              <Spinner />
+            </div>
+          }
+        >
           <FindEmailSecondStep
             defaultValues={stepHistory.step2}
             name={stepHistory.step1.name}
@@ -83,7 +95,16 @@ function FindEmail() {
         </Suspense>
       )}
       {currentStep === 3 && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense
+          fallback={
+            <div
+              className="flex flex-col items-center justify-center"
+              style={{ height: STEP_WRAPPER_HEIGHT }}
+            >
+              <Spinner className="border-success-500" />
+            </div>
+          }
+        >
           <FindEmailThirdStep email={stepHistory.step3.email} />
         </Suspense>
       )}

--- a/src/pages/auth/FindPassword.tsx
+++ b/src/pages/auth/FindPassword.tsx
@@ -9,6 +9,7 @@ import FindPasswordFirstStep from '@/components/auth/find-password/FindPasswordF
 import { InputFieldColStyle } from '@/constants/auth-variants'
 import { cn } from '@/utils'
 import { useResetPassword } from '@/hooks/api/auth/useResetPassword'
+import { Spinner } from '@/components'
 
 const FindPasswordSecondStep = lazy(
   () => import('@/components/auth/find-password/FindPasswordSecondStep')
@@ -18,6 +19,8 @@ const FindPasswordThirdStep = lazy(
 )
 
 const FIND_EMAIL_STEP_LIST = ['이메일입력', '이메일인증', '비밀번호재설정']
+
+const STEP_WRAPPER_HEIGHT = 366
 
 function FindPassword() {
   const [currentStep, setCurrentStep] = useState(1)
@@ -56,7 +59,16 @@ function FindPassword() {
         />
       )}
       {currentStep === 2 && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense
+          fallback={
+            <div
+              className="flex flex-col items-center justify-center"
+              style={{ height: STEP_WRAPPER_HEIGHT }}
+            >
+              <Spinner />
+            </div>
+          }
+        >
           <FindPasswordSecondStep
             defaultValues={stepHistory.step2}
             email={stepHistory.step1.email}
@@ -80,7 +92,16 @@ function FindPassword() {
         </Suspense>
       )}
       {currentStep === 3 && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense
+          fallback={
+            <div
+              className="flex flex-col items-center justify-center"
+              style={{ height: STEP_WRAPPER_HEIGHT }}
+            >
+              <Spinner />
+            </div>
+          }
+        >
           <FindPasswordThirdStep
             defaultValues={stepHistory.step3}
             onNext={(value) => {

--- a/src/routes/MainRoutes.tsx
+++ b/src/routes/MainRoutes.tsx
@@ -2,7 +2,7 @@ import RootLayout from '@/components/layout/RootLayout'
 import { Route, Routes } from 'react-router'
 import { lazy, Suspense } from 'react'
 import LandingPage from '@/pages/LandingPage'
-import NaverAuth from '@/pages/auth/NaverAuth'
+import Spinner from '@/components/common/Spinner'
 
 // layouts
 const AuthLayout = lazy(() => import('@/components/layout/AuthLayout'))
@@ -24,10 +24,17 @@ const FindEmail = lazy(() => import('@/pages/auth/FindEmail'))
 const FindPassword = lazy(() => import('@/pages/auth/FindPassword'))
 const NotFound = lazy(() => import('@/pages/NotFound'))
 const KakaoAuth = lazy(() => import('@/pages/auth/KakaoAuth'))
+const NaverAuth = lazy(() => import('@/pages/auth/NaverAuth'))
 
 function MainRoutes() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex h-dvh flex-col items-center justify-center">
+          <Spinner />
+        </div>
+      }
+    >
       <Routes>
         <Route path="/" element={<RootLayout />}>
           <Route index element={<LandingPage />} />


### PR DESCRIPTION
## 🚀 PR 요약

Suspense fallback에 spinner을 적용했습니다.

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **MainRoutes.tsx**의 `Suspense fallback`에 spinner 적용
- **FindEmail.tsx**의 `Suspense fallback`에 spinner 적용
- **FindPasswordtsx**의 `Suspense fallback`에 spinner 적용

### 스크린 샷

예시로 **FindEmail** 페이지 스크린 샷을 첨부했고, 모든 `Suspense fallback`에 동일한 spinner을 적용했습니다.

![StudyHub-Chrome2025-09-3020-27-56-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ab8f2a0d-bed4-435e-8601-969ff768704c)

## 🔗 연관된 이슈

> closes #300
