### PR TITLE
Fix: 네이버 소셜 로그인 수정

### DIFF
--- a/src/constants/oauth-constants.ts
+++ b/src/constants/oauth-constants.ts
@@ -8,8 +8,9 @@ export const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID
 
 export const NAVER_CLIENT_SECRET = import.meta.env.VITE_NAVER_CLIENT_ID
 
-export const NAVER_STATE = 'abcdefg'
+// export const NAVER_STATE = 'abcdefg'
 
 export const NAVER_REDIRECT_URI = import.meta.env.VITE_NAVER_REDIRECT_URI
 
-export const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&state=${NAVER_STATE}&redirect_uri=${NAVER_REDIRECT_URI}`
+export const NAVER_AUTH_URL = (state: string) =>
+  `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&state=${state}&redirect_uri=${NAVER_REDIRECT_URI}`

--- a/src/hooks/api/auth/useNaverCallback.ts
+++ b/src/hooks/api/auth/useNaverCallback.ts
@@ -1,10 +1,10 @@
-import { NAVER_STATE } from '@/constants/oauth-constants'
 import { API_BASE_URL } from '@/constants/url-constants'
 import { useToast } from '@/hooks'
 import { useLoginStore } from '@/store/useLoginStore'
 import type { UserNaverLogin } from '@/types/api-request-types/auth-request-types'
 import { setAccessToken } from '@/utils'
 import api from '@/utils/axios'
+import { clearNaverState } from '@/utils/manage-naver-state'
 import {
   useMutation,
   useQueryClient,
@@ -23,10 +23,10 @@ export default function useNaverCallback(
   return useMutation<string, Error, UserNaverLogin>({
     ...options,
     mutationKey: ['auth', 'naver', 'callback'],
-    mutationFn: async ({ code }) => {
+    mutationFn: async ({ code, state }) => {
       const response = await api.post(`${API_BASE_URL}/auth/naver/callback`, {
         code: code,
-        state: NAVER_STATE,
+        state: state,
       })
       const newAccessToken = response.data.access_token
       return newAccessToken
@@ -41,10 +41,12 @@ export default function useNaverCallback(
         '네이버 로그인이 완료되었습니다.'
       )
       navigate('/')
+      clearNaverState()
     },
     onError: () => {
       triggerToast('error', '잠시 후 다시 시도해주세요')
       navigate('/auth/login')
+      clearNaverState()
     },
   })
 }

--- a/src/hooks/api/auth/useNaverCallback.ts
+++ b/src/hooks/api/auth/useNaverCallback.ts
@@ -1,3 +1,4 @@
+import { NAVER_STATE } from '@/constants/oauth-constants'
 import { API_BASE_URL } from '@/constants/url-constants'
 import { useToast } from '@/hooks'
 import { useLoginStore } from '@/store/useLoginStore'
@@ -25,6 +26,7 @@ export default function useNaverCallback(
     mutationFn: async ({ code }) => {
       const response = await api.post(`${API_BASE_URL}/auth/naver/callback`, {
         code: code,
+        state: NAVER_STATE,
       })
       const newAccessToken = response.data.access_token
       return newAccessToken

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -29,6 +29,7 @@ import { useState } from 'react'
 import { AxiosError } from 'axios'
 import { useWithdrawalDateStore } from '@/store'
 import { KAKAO_AUTH_URL, NAVER_AUTH_URL } from '@/constants/oauth-constants'
+import { createNaverState, setNaverState } from '@/utils/manage-naver-state'
 
 function Login() {
   const {
@@ -76,7 +77,9 @@ function Login() {
   }
 
   const handleNaverLogin = () => {
-    window.location.href = NAVER_AUTH_URL
+    const str = createNaverState()
+    setNaverState(str)
+    window.location.href = NAVER_AUTH_URL(str)
   }
 
   return (

--- a/src/pages/auth/NaverAuth.tsx
+++ b/src/pages/auth/NaverAuth.tsx
@@ -1,4 +1,5 @@
 import useNaverCallback from '@/hooks/api/auth/useNaverCallback'
+import { getNaverState } from '@/utils/manage-naver-state'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router'
 
@@ -6,13 +7,14 @@ function NaverAuth() {
   const naverCallback = useNaverCallback()
   const [searchParams] = useSearchParams()
   const code = searchParams.get('code')
+  const state = getNaverState()
 
   useEffect(() => {
-    if (!code) return
+    if (!code || !state) return
 
-    naverCallback.mutate({ code })
+    naverCallback.mutate({ code, state })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [code])
+  }, [code, state])
 
   return <div>네이버 로그인 중...</div>
 }

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -44,6 +44,7 @@ export interface UserKakaoLogin {
 
 export interface UserNaverLogin {
   code: string
+  state: string
 }
 
 export interface UserFindEmailSendCode {

--- a/src/utils/manage-naver-state.ts
+++ b/src/utils/manage-naver-state.ts
@@ -1,0 +1,17 @@
+const STATE_KEY = 'naver_oauth_state'
+
+export function createNaverState() {
+  return encodeURIComponent(Math.random().toString(16).slice(2))
+}
+
+export function setNaverState(state: string) {
+  sessionStorage.setItem(STATE_KEY, state)
+}
+
+export function getNaverState() {
+  return sessionStorage.getItem(STATE_KEY)
+}
+
+export function clearNaverState() {
+  sessionStorage.removeItem(STATE_KEY)
+}


### PR DESCRIPTION
## 🚀 PR 요약

`NAVER_AUTH_URL`에 들어가는 `state`에 임의의 값을 생성하여 보내도록 수정했습니다.

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- **naver state** 관리 유틸 생성
  - `createNaverState`: 임의의 string 값 생성
  - `setNaverState`: 세션 스토리지에 naver_oauth_state라는 키와 인자로 전달 받은 임의값 저장
  - `getNaverState`: 세션 스토리지에서 naver_oauth_state라는 키에 해당하는 값 조회
  - `removeNaverState`: 세션 스토리지에서 naver_oauth_state라는 키에 해당하는 값 삭제
- `useNaverCallback`에서 `code`와 `state`를 **request body**로 전달하도록 수정

### 참고 사항

- 문제 없이 작동하는 지 테스트 완료했습니다.
- 필요한 환경변수(env) vercel에 추가 완료했습니다.

  - **VITE_NAVER_CLIENT_ID**: 네이버 소셜 로그인 client id
  - **VITE_NAVER_REDIRECT_URI**: 네이버 소셜 로그인 redirct uri

### 스크린 샷

![StudyHub-Chrome2025-10-0110-42-10-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/be717b52-49cf-4759-b7ce-e92538aac375)

## 🔗 연관된 이슈

> closes #309
